### PR TITLE
Support heterogeneous precision for primitive operations

### DIFF
--- a/arrayjit/lib/assignments.ml
+++ b/arrayjit/lib/assignments.ml
@@ -300,7 +300,7 @@ let%track4_sexp to_low_level code =
                 | Ops.Void_prec -> failwith "Cannot use vector operation with void precision")
           in
           Set_from_vec
-            { tn = lhs; idcs = lhs_idcs; length; vec_unop = op; arg = rhs_ll; debug = "" }
+            { tn = lhs; idcs = lhs_idcs; length; vec_unop = op; arg = (rhs_ll, Low_level.scalar_precision rhs_ll); debug = "" }
         in
         let rec for_loop rev_iters = function
           | [] -> basecase rev_iters

--- a/arrayjit/lib/assignments.ml
+++ b/arrayjit/lib/assignments.ml
@@ -300,7 +300,14 @@ let%track4_sexp to_low_level code =
                 | Ops.Void_prec -> failwith "Cannot use vector operation with void precision")
           in
           Set_from_vec
-            { tn = lhs; idcs = lhs_idcs; length; vec_unop = op; arg = (rhs_ll, Low_level.scalar_precision rhs_ll); debug = "" }
+            {
+              tn = lhs;
+              idcs = lhs_idcs;
+              length;
+              vec_unop = op;
+              arg = (rhs_ll, Low_level.scalar_precision rhs_ll);
+              debug = "";
+            }
         in
         let rec for_loop rev_iters = function
           | [] -> basecase rev_iters

--- a/arrayjit/lib/c_syntax.ml
+++ b/arrayjit/lib/c_syntax.ml
@@ -398,18 +398,15 @@ module C_syntax (B : C_syntax_config) = struct
             ~args_docs:[]
         else string "/* " ^^ string message ^^ string " */"
     | Staged_compilation callback -> callback ()
-    | Set_from_vec { tn; idcs; length; vec_unop; arg; debug } ->
+    | Set_from_vec { tn; idcs; length; vec_unop; arg = arg, arg_prec; debug } ->
         let ident_doc = string (get_ident tn) in
         let dims = Lazy.force tn.dims in
         let prec = Lazy.force tn.prec in
         (* Determine argument precision based on operation homogeneity *)
         let arg_prec =
-          if Ops.is_homogeneous_prec_vec_unop vec_unop then
-            prec  (* Homogeneous: argument uses result precision *)
-          else
-            (* Heterogeneous: argument needs specific precision *)
-            match vec_unop with
-            | Ops.Uint4x32_to_prec_uniform -> Ops.uint4x32
+          if Ops.is_homogeneous_prec_vec_unop vec_unop then prec
+            (* Homogeneous: argument uses result precision *)
+          else arg_prec
         in
         let local_defs, arg_doc = pp_scalar arg_prec arg in
         let local_defs = pp_local_defs local_defs in
@@ -571,9 +568,9 @@ module C_syntax (B : C_syntax_config) = struct
         let idx_doc = if PPrint.is_empty idx_doc then string "0" else idx_doc in
         let expr = string prefix ^^ idx_doc ^^ string postfix in
         ([], expr)
-    | Binop (Arg1, v1, _v2) -> pp_scalar prec v1
-    | Binop (Arg2, _v1, v2) -> pp_scalar prec v2
-    | Ternop (op, v1, v2, v3) ->
+    | Binop (Arg1, (v1, _), _v2) -> pp_scalar prec v1
+    | Binop (Arg2, _v1, (v2, _)) -> pp_scalar prec v2
+    | Ternop (op, (v1, v1_prec), (v2, v2_prec), (v3, v3_prec)) ->
         let d1, e1, d2, e2, d3, e3 =
           if Ops.is_homogeneous_prec_ternop op then
             (* Homogeneous: all arguments use result precision *)
@@ -588,21 +585,24 @@ module C_syntax (B : C_syntax_config) = struct
                 (* For Where: condition keeps its precision, then/else use result precision *)
                 (* Note: we evaluate condition without precision conversion, but then/else
                    need to match the result precision for the final assignment *)
-                let d1, e1 = pp_scalar Ops.Void_prec v1 in  (* condition: no conversion *)
-                let d2, e2 = pp_scalar prec v2 in           (* then: result precision *)
-                let d3, e3 = pp_scalar prec v3 in           (* else: result precision *)
+                let d1, e1 = pp_scalar v1_prec v1 in
+                (* condition: no conversion *)
+                let d2, e2 = pp_scalar prec v2 in
+                (* then: result precision *)
+                let d3, e3 = pp_scalar prec v3 in
+                (* else: result precision *)
                 (d1, e1, d2, e2, d3, e3)
             | _ ->
                 (* Other heterogeneous ternary ops would go here *)
-                let d1, e1 = pp_scalar prec v1 in
-                let d2, e2 = pp_scalar prec v2 in
-                let d3, e3 = pp_scalar prec v3 in
+                let d1, e1 = pp_scalar v1_prec v1 in
+                let d2, e2 = pp_scalar v2_prec v2 in
+                let d3, e3 = pp_scalar v3_prec v3 in
                 (d1, e1, d2, e2, d3, e3)
         in
         let defs = List.concat [ d1; d2; d3 ] in
         let expr = group (B.ternop_syntax prec op e1 e2 e3) in
         (defs, expr)
-    | Binop (op, v1, v2) ->
+    | Binop (op, (v1, v1_prec), (v2, v2_prec)) ->
         let d1, e1, d2, e2 =
           if Ops.is_homogeneous_prec_binop op then
             (* Homogeneous: both arguments use result precision *)
@@ -612,22 +612,18 @@ module C_syntax (B : C_syntax_config) = struct
           else
             (* Heterogeneous: arguments keep their natural precision *)
             (* Currently all binops are homogeneous, but this is here for future extension *)
-            let d1, e1 = pp_scalar Ops.Void_prec v1 in
-            let d2, e2 = pp_scalar Ops.Void_prec v2 in
+            let d1, e1 = pp_scalar v1_prec v1 in
+            let d2, e2 = pp_scalar v2_prec v2 in
             (d1, e1, d2, e2)
         in
         let defs = List.concat [ d1; d2 ] in
         let expr = group (B.binop_syntax prec op e1 e2) in
         (defs, expr)
-    | Unop (op, v) ->
+    | Unop (op, (v, v_prec)) ->
         let arg_prec =
-          if Ops.is_homogeneous_prec_unop op then
-            prec  (* Homogeneous: argument uses result precision *)
-          else
-            (* Heterogeneous: argument needs specific precision *)
-            match op with
-            | Ops.Uint4x32_to_prec_uniform1 -> Ops.uint4x32
-            | _ -> Ops.Void_prec  (* No conversion for other heterogeneous ops *)
+          if Ops.is_homogeneous_prec_unop op then prec
+            (* Homogeneous: argument uses result precision *)
+          else v_prec
         in
         let defs, expr_v = pp_scalar arg_prec v in
         let expr = group (B.unop_syntax prec op expr_v) in
@@ -691,9 +687,9 @@ module C_syntax (B : C_syntax_config) = struct
     | Embed_index idx ->
         let idx_doc = pp_axis_index idx in
         ((if PPrint.is_empty idx_doc then string "0" else idx_doc), [])
-    | Binop (Arg1, v1, _v2) -> debug_float prec v1
-    | Binop (Arg2, _v1, v2) -> debug_float prec v2
-    | Ternop (op, v1, v2, v3) ->
+    | Binop (Arg1, (v1, _), _v2) -> debug_float prec v1
+    | Binop (Arg2, _v1, (v2, _)) -> debug_float prec v2
+    | Ternop (op, (v1, v1_prec), (v2, v2_prec), (v3, v3_prec)) ->
         let v1_doc, idcs1, v2_doc, idcs2, v3_doc, idcs3 =
           if Ops.is_homogeneous_prec_ternop op then
             (* Homogeneous: all arguments use result precision *)
@@ -705,18 +701,21 @@ module C_syntax (B : C_syntax_config) = struct
             (* Heterogeneous: handle based on operation *)
             match op with
             | Ops.Where ->
-                let v1_doc, idcs1 = debug_float Ops.Void_prec v1 in  (* condition: no conversion *)
-                let v2_doc, idcs2 = debug_float prec v2 in           (* then: result precision *)
-                let v3_doc, idcs3 = debug_float prec v3 in           (* else: result precision *)
+                let v1_doc, idcs1 = debug_float v1_prec v1 in
+                (* condition: no conversion *)
+                let v2_doc, idcs2 = debug_float prec v2 in
+                (* then: result precision *)
+                let v3_doc, idcs3 = debug_float prec v3 in
+                (* else: result precision *)
                 (v1_doc, idcs1, v2_doc, idcs2, v3_doc, idcs3)
             | _ ->
-                let v1_doc, idcs1 = debug_float prec v1 in
-                let v2_doc, idcs2 = debug_float prec v2 in
-                let v3_doc, idcs3 = debug_float prec v3 in
+                let v1_doc, idcs1 = debug_float v1_prec v1 in
+                let v2_doc, idcs2 = debug_float v2_prec v2 in
+                let v3_doc, idcs3 = debug_float v3_prec v3 in
                 (v1_doc, idcs1, v2_doc, idcs2, v3_doc, idcs3)
         in
         (B.ternop_syntax prec op v1_doc v2_doc v3_doc, idcs1 @ idcs2 @ idcs3)
-    | Binop (op, v1, v2) ->
+    | Binop (op, (v1, v1_prec), (v2, v2_prec)) ->
         let v1_doc, idcs1, v2_doc, idcs2 =
           if Ops.is_homogeneous_prec_binop op then
             (* Homogeneous: both arguments use result precision *)
@@ -725,20 +724,16 @@ module C_syntax (B : C_syntax_config) = struct
             (v1_doc, idcs1, v2_doc, idcs2)
           else
             (* Heterogeneous: arguments keep their natural precision *)
-            let v1_doc, idcs1 = debug_float Ops.Void_prec v1 in
-            let v2_doc, idcs2 = debug_float Ops.Void_prec v2 in
+            let v1_doc, idcs1 = debug_float v1_prec v1 in
+            let v2_doc, idcs2 = debug_float v2_prec v2 in
             (v1_doc, idcs1, v2_doc, idcs2)
         in
         (B.binop_syntax prec op v1_doc v2_doc, idcs1 @ idcs2)
-    | Unop (op, v) ->
+    | Unop (op, (v, v_prec)) ->
         let arg_prec =
-          if Ops.is_homogeneous_prec_unop op then
-            prec  (* Homogeneous: argument uses result precision *)
-          else
-            (* Heterogeneous: argument needs specific precision *)
-            match op with
-            | Ops.Uint4x32_to_prec_uniform1 -> Ops.uint4x32
-            | _ -> Ops.Void_prec  (* No conversion for other heterogeneous ops *)
+          if Ops.is_homogeneous_prec_unop op then prec
+            (* Homogeneous: argument uses result precision *)
+          else v_prec
         in
         let v_doc, idcs = debug_float arg_prec v in
         (B.unop_syntax prec op v_doc, idcs)

--- a/arrayjit/lib/low_level.ml
+++ b/arrayjit/lib/low_level.ml
@@ -1106,25 +1106,26 @@ let simplify_llc llc =
           | Constant c, _ when Float.is_integer c ->
               loop_scalar (unroll_pow ~base:v1_scalar ~exp:(Float.to_int c), prec)
           | _ -> result)
-    | Binop (Add, (Binop (Mul, llv1, llv2), prec12), llv3) | Binop (Add, llv3, (Binop (Mul, llv1, llv2), prec12)) ->
+    | Binop (Add, (Binop (Mul, llv1, llv2), prec12), llv3)
+    | Binop (Add, llv3, (Binop (Mul, llv1, llv2), prec12)) ->
         (* TODO: this is tentative. *)
         loop_scalar @@ (Ternop (FMA, llv1, llv2, llv3), Ops.promote_prec prec12 prec)
     | Binop (op, llv1, llv2) ->
         let v1 = loop_scalar llv1 in
         let v2 = loop_scalar llv2 in
-        let result = Binop (op, v1, v2), prec in
+        let result = (Binop (op, v1, v2), prec) in
         if equal_scalar_arg llv1 v1 && equal_scalar_arg llv2 v2 then result else loop_scalar result
     | Ternop (op, llv1, llv2, llv3) ->
         let v1 = loop_scalar llv1 in
         let v2 = loop_scalar llv2 in
         let v3 = loop_scalar llv3 in
-        let result = Ternop (op, v1, v2, v3), prec in
+        let result = (Ternop (op, v1, v2, v3), prec) in
         if equal_scalar_arg llv1 v1 && equal_scalar_arg llv2 v2 then result else loop_scalar result
     | Unop (Identity, llsc) -> loop_scalar llsc
     | Unop (op, (Constant c, _)) -> (Constant (Ops.interpret_unop op c), prec)
     | Unop (op, llsc) ->
         let v = loop_scalar llsc in
-        let result = Unop (op, v), prec in
+        let result = (Unop (op, v), prec) in
         if equal_scalar_arg llsc v then result else loop_scalar result
   in
   let check_constant tn c =

--- a/arrayjit/lib/low_level.mli
+++ b/arrayjit/lib/low_level.mli
@@ -35,7 +35,7 @@ type t =
       idcs : Indexing.axis_index array;
       length : int;
       vec_unop : Ops.vec_unop;
-      arg : scalar_t;
+      arg : scalar_arg;
       mutable debug : string;
     }
   | Set_local of scope_id * scalar_t
@@ -46,14 +46,19 @@ and scalar_t =
   | Get_local of scope_id
   | Get of Tnode.t * Indexing.axis_index array
   | Get_merge_buffer of Tnode.t * Indexing.axis_index array
-  | Ternop of Ops.ternop * scalar_t * scalar_t * scalar_t
-  | Binop of Ops.binop * scalar_t * scalar_t
-  | Unop of Ops.unop * scalar_t
+  | Ternop of Ops.ternop * scalar_arg * scalar_arg * scalar_arg
+  | Binop of Ops.binop * scalar_arg * scalar_arg
+  | Unop of Ops.unop * scalar_arg
   | Constant of float
   | Constant_bits of int64  (** Direct bit representation, primarily for uint4x32 *)
   | Embed_index of Indexing.axis_index
 [@@deriving sexp_of, equal, compare]
 
+and scalar_arg = scalar_t * Ops.prec [@@deriving sexp_of, equal, compare]
+(** The argument precision is preserved in heterogeneous precision operation arguments, and is
+    ignored (overridden) in homogeneous precision operations. *)
+
+val scalar_precision : scalar_t -> Ops.prec
 val apply_op : Ops.op -> scalar_t array -> scalar_t
 val flat_lines : t list -> t list
 val unflat_lines : t list -> t

--- a/arrayjit/lib/ndarray.ml
+++ b/arrayjit/lib/ndarray.ml
@@ -222,6 +222,8 @@ let compute_end_idx ?padding dims axis =
   | Some _ -> dims.(axis) - 1
 
 let set_from_float ?padding arr idx v =
+  (* NOTE: Bigarray requires the length of indices to be the same as the number of dimensions. *)
+  let idx = if Array.is_empty (dims arr) then [||] else idx in
   let adjusted_idx = adjust_idx_for_padding ?padding idx in
   match arr with
   | Byte_nd arr -> A.set arr adjusted_idx @@ Char.of_int_exn @@ Int.of_float v
@@ -388,7 +390,7 @@ let retrieve_flat_values ?padding arr =
 
 let set_flat_values ?padding arr values =
   let dims = dims arr in
-  if Array.is_empty dims then set_from_float ?padding arr [| 0 |] values.(0)
+  if Array.is_empty dims then set_from_float ?padding arr [||] values.(0)
   else
     let n_axes = Array.length dims in
     let idx = Array.create ~len:n_axes 0 in

--- a/arrayjit/lib/ops.ml
+++ b/arrayjit/lib/ops.ml
@@ -809,6 +809,30 @@ external bfloat16_to_uint4x32 : int -> int array = "arrayjit_bfloat16_to_uint4x3
 external half_to_uint4x32 : int -> int array = "arrayjit_half_to_uint4x32_ocaml"
 external fp8_to_uint4x32 : int -> int array = "arrayjit_fp8_to_uint4x32_ocaml"
 
+(** {2 *** Precision homogeneity classification ***} *)
+
+(** Returns true if the unary operation is homogeneous in precision, meaning
+    its argument should be converted to the result precision. *)
+let is_homogeneous_prec_unop = function
+  | Uint4x32_to_prec_uniform1 -> false  (* Heterogeneous: argument must be uint4x32 *)
+  | _ -> true  (* All other unary operations are homogeneous *)
+
+(** Returns true if the vec_unop operation is homogeneous in precision, meaning
+    its argument should be converted to the result precision. *)
+let is_homogeneous_prec_vec_unop = function
+  | Uint4x32_to_prec_uniform -> false  (* Heterogeneous: argument must be uint4x32 *)
+
+(** Returns true if the binary operation is homogeneous in precision, meaning
+    its arguments should be converted to the result precision. *)
+let is_homogeneous_prec_binop = function
+  | _ -> true  (* All binary operations are currently homogeneous *)
+
+(** Returns true if the ternary operation is homogeneous in precision, meaning
+    its arguments should be converted to the result precision. *)
+let is_homogeneous_prec_ternop = function
+  | Where -> false  (* Heterogeneous: condition can have different precision *)
+  | FMA -> true     (* FMA is homogeneous *)
+
 let () =
   (* Ensure that the functions are linked in *)
   let _ = bfloat16_to_single 0 in

--- a/arrayjit/lib/ops.ml
+++ b/arrayjit/lib/ops.ml
@@ -811,27 +811,27 @@ external fp8_to_uint4x32 : int -> int array = "arrayjit_fp8_to_uint4x32_ocaml"
 
 (** {2 *** Precision homogeneity classification ***} *)
 
-(** Returns true if the unary operation is homogeneous in precision, meaning
-    its argument should be converted to the result precision. *)
+(** Returns true if the unary operation is homogeneous in precision, meaning its argument should be
+    converted to the result precision. *)
 let is_homogeneous_prec_unop = function
-  | Uint4x32_to_prec_uniform1 -> false  (* Heterogeneous: argument must be uint4x32 *)
-  | _ -> true  (* All other unary operations are homogeneous *)
+  | Uint4x32_to_prec_uniform1 -> false (* Heterogeneous: argument must be uint4x32 *)
+  | _ -> true (* All other unary operations are homogeneous *)
 
-(** Returns true if the vec_unop operation is homogeneous in precision, meaning
-    its argument should be converted to the result precision. *)
+(** Returns true if the vec_unop operation is homogeneous in precision, meaning its argument should
+    be converted to the result precision. *)
 let is_homogeneous_prec_vec_unop = function
-  | Uint4x32_to_prec_uniform -> false  (* Heterogeneous: argument must be uint4x32 *)
+  | Uint4x32_to_prec_uniform -> false (* Heterogeneous: argument must be uint4x32 *)
 
-(** Returns true if the binary operation is homogeneous in precision, meaning
-    its arguments should be converted to the result precision. *)
+(** Returns true if the binary operation is homogeneous in precision, meaning its arguments should
+    be converted to the result precision. *)
 let is_homogeneous_prec_binop = function
-  | _ -> true  (* All binary operations are currently homogeneous *)
+  | _ -> true (* All binary operations are currently homogeneous *)
 
-(** Returns true if the ternary operation is homogeneous in precision, meaning
-    its arguments should be converted to the result precision. *)
+(** Returns true if the ternary operation is homogeneous in precision, meaning its arguments should
+    be converted to the result precision. *)
 let is_homogeneous_prec_ternop = function
-  | Where -> false  (* Heterogeneous: condition can have different precision *)
-  | FMA -> true     (* FMA is homogeneous *)
+  | Where -> false (* Heterogeneous: condition can have different precision *)
+  | FMA -> true (* FMA is homogeneous *)
 
 let () =
   (* Ensure that the functions are linked in *)

--- a/lib/operation.ml
+++ b/lib/operation.ml
@@ -401,7 +401,7 @@ let where ?(label = []) ~grad_spec t1 t2 t3 =
   Tensor.ternop ~label:("where" :: label) ~ternary_op:Pointwise_tern ~op_asn ~grad_asn ~grad_spec t1
     t2 t3
 
-(** [range] is a 1D tensor of shape [upto], spans [[0, upto)]. *)
+(** [range] is a 1D tensor of shape [upto], spans [0] inclusive, [upto] exclusive. *)
 let range ?(label = []) ?(grad_spec = Tensor.Prohibit_grad) ?axis_label upto =
   let result =
     Tensor.term ~fetch_op:Range_over_offsets ~grad_spec ~batch_dims:[]

--- a/test/operations/dune
+++ b/test/operations/dune
@@ -148,6 +148,29 @@
      top_down_prec.%{read:config/ocannl_backend_extension.txt}.actual)))))
 
 (rule
+ (targets
+  test_where_precision-unoptimized.ll.actual
+  test_where_precision.%{read:config/ocannl_backend_extension.txt}.actual)
+ (package neural_nets_lib)
+ (deps
+  config/ocannl_backend_extension.txt
+  ocannl_config
+  (env_var OCANNL_BACKEND))
+ (action
+  (no-infer
+   (progn
+    (run
+     %{dep:test_where_precision.exe}
+     "--ocannl_output_prec_in_ll_files=true"
+     "--ocannl_output_debug_files_in_build_directory=true")
+    (copy
+     build_files/where_fwd-unoptimized.ll
+     test_where_precision-unoptimized.ll.actual)
+    (copy
+     build_files/where_fwd.%{read:config/ocannl_backend_extension.txt}
+     test_where_precision.%{read:config/ocannl_backend_extension.txt}.actual)))))
+
+(rule
  (alias runtest)
  (package neural_nets_lib)
  (action
@@ -173,6 +196,25 @@
   (diff
    "top_down_prec.%{read:config/ocannl_backend_extension.txt}.expected"
    "top_down_prec.%{read:config/ocannl_backend_extension.txt}.actual")))
+
+(rule
+ (alias runtest)
+ (package neural_nets_lib)
+ (action
+  (diff
+   "test_where_precision-unoptimized.ll.expected"
+   "test_where_precision-unoptimized.ll.actual")))
+
+(rule
+ (alias runtest)
+ (package neural_nets_lib)
+ (deps
+  config/ocannl_backend_extension.txt
+  (env_var OCANNL_BACKEND))
+ (action
+  (diff
+   "test_where_precision.%{read:config/ocannl_backend_extension.txt}.expected"
+   "test_where_precision.%{read:config/ocannl_backend_extension.txt}.actual")))
 
 (test
  (name test_vec_simple)
@@ -218,6 +260,17 @@
  (preprocess
   (pps ppx_here ppx_ocannl))
  (modes exe))
+
+(test
+ (name test_where_precision)
+ (package neural_nets_lib)
+ (deps
+  ocannl_config
+  (env_var OCANNL_BACKEND))
+ (modules test_where_precision)
+ (libraries base ocannl)
+ (preprocess
+  (pps ppx_here ppx_ocannl)))
 
 (test
  (name test_uniform1)

--- a/test/operations/test_where_precision-unoptimized.ll.expected
+++ b/test/operations/test_where_precision-unoptimized.ll.expected
@@ -1,0 +1,5 @@
+
+where_fwd (): /* where fwd */
+
+  where<single>[] := where(cond_condition<byte>[], a_then_val<half>[], b_else_val<bfloat16>[]);
+  /* end */

--- a/test/operations/test_where_precision.c.expected
+++ b/test/operations/test_where_precision.c.expected
@@ -1,0 +1,87 @@
+
+#include <stdio.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* No longer need export macros since we're using textual prepending */
+
+
+#ifdef __FLT16_MAX__
+  #define HAS_NATIVE_FLOAT16 1
+#else
+  #define HAS_NATIVE_FLOAT16 0
+#endif
+
+
+#if HAS_NATIVE_FLOAT16
+  #define HALF_T _Float16
+#else
+  #define HALF_T uint16_t
+#endif
+
+
+#if HAS_NATIVE_FLOAT16
+  #define HALF_TO_FLOAT(x) ((float)(x))
+#else
+  #define HALF_TO_FLOAT(x) half_to_float_emulated(x)
+#endif
+
+
+#if !HAS_NATIVE_FLOAT16
+/* Convert IEEE 754 half precision (stored as uint16_t) to float */
+static float half_to_float_emulated(uint16_t h) {
+    uint32_t sign = (h >> 15) & 0x1;
+    uint32_t exponent = (h >> 10) & 0x1F;
+    uint32_t mantissa = h & 0x3FF;
+    
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            /* Zero */
+            return sign ? -0.0f : 0.0f;
+        } else {
+            /* Subnormal */
+            float result = ldexpf(mantissa / 1024.0f, -14);
+            return sign ? -result : result;
+        }
+    } else if (exponent == 31) {
+        if (mantissa == 0) {
+            /* Infinity */
+            return sign ? -INFINITY : INFINITY;
+        } else {
+            /* NaN */
+            return NAN;
+        }
+    } else {
+        /* Normal number */
+        float result = ldexpf(1.0f + mantissa / 1024.0f, exponent - 15);
+        return sign ? -result : result;
+    }
+}
+#endif
+
+
+/* BFloat16 to Float conversion (C function) */
+float bfloat16_to_single(uint16_t bf16)
+{
+  /* BFloat16 format: 1 sign bit, 8 exponent bits, 7 mantissa bits
+     To convert to float32, we shift left by 16 bits */
+  uint32_t f32 = ((uint32_t)bf16) << 16;
+  return *((float *)&f32);
+}
+
+ void where_fwd(
+    HALF_T *a_then_val,
+    float *where,
+    unsigned char *cond_condition,
+    unsigned short *b_else_val) {
+
+  /* Local declarations and initialization. */
+
+  /* Main logic. */
+  /* where fwd */
+  where[0] =
+      ((cond_condition[0]) != 0.0 ? ( HALF_TO_FLOAT(a_then_val[0])) : ( bfloat16_to_single(b_else_val[0])));
+  /* end */
+}

--- a/test/operations/test_where_precision.cu.expected
+++ b/test/operations/test_where_precision.cu.expected
@@ -1,0 +1,1 @@
+FIXME: soon we will update the CUDA backend wholesale to catch up with recent work

--- a/test/operations/test_where_precision.expected
+++ b/test/operations/test_where_precision.expected
@@ -1,0 +1,6 @@
+Retrieving commandline, environment, or config file variable ocannl_log_level
+Found 0, in the config file
+                 #3 where
+                 scalar 0.00
+#0 cond_condition│#1 a_then_val│#2 b_else_val
+scalar 0.00      │scalar 0.00  │scalar 0.00

--- a/test/operations/test_where_precision.expected
+++ b/test/operations/test_where_precision.expected
@@ -1,6 +1,6 @@
 Retrieving commandline, environment, or config file variable ocannl_log_level
 Found 0, in the config file
                  #3 where
-                 scalar 0.00
+                 scalar 2.00
 #0 cond_condition│#1 a_then_val│#2 b_else_val
-scalar 0.00      │scalar 0.00  │scalar 0.00
+scalar 0.00      │scalar 1.00  │scalar 2.00

--- a/test/operations/test_where_precision.metal.expected
+++ b/test/operations/test_where_precision.metal.expected
@@ -1,0 +1,17 @@
+#include <metal_stdlib>
+using namespace metal;
+kernel void where_fwd(
+    device bfloat *b_else_val [[buffer(0)]],
+    device float *where [[buffer(1)]],
+    device half *a_then_val [[buffer(2)]],
+    device uchar *cond_condition [[buffer(3)]],
+    uint3 gid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) {
+
+  /* Local declarations and initialization. */
+
+  /* Main logic. */
+  /* where fwd */
+  where[0] = select((float)(b_else_val[0]), (float)(a_then_val[0]), cond_condition[0]);
+  /* end */
+}

--- a/test/operations/test_where_precision.ml
+++ b/test/operations/test_where_precision.ml
@@ -1,0 +1,26 @@
+open Base
+module Tensor = Ocannl.Tensor
+module Train = Ocannl.Train
+module NTDSL = Ocannl.Operation.NTDSL
+module Tn = Ir.Tnode
+
+let () =
+  Tensor.unsafe_reinitialize ();
+  let module Backend = (val Backends.fresh_backend ()) in
+  
+  (* Test heterogeneous precision in where operation using %cd syntax *)
+  let%cd condition = { cond } in
+  let%cd then_val = { a } in  
+  let%cd else_val = { b } in
+  let%cd result = where condition then_val else_val in
+  
+  (* Set different precisions for each argument *)
+  Tn.update_prec condition.value Ir.Ops.byte;  (* condition uses byte precision *)
+  Tn.update_prec then_val.value Ir.Ops.half;            (* then branch is half *)
+  Tn.update_prec else_val.value Ir.Ops.bfloat16;        (* else branch is bfloat16 *)
+  Tn.update_prec result.value Ir.Ops.single;            (* result is single *)
+  
+  (* Set up values and run computation *)
+  Train.set_hosted result.value;
+  ignore (Train.forward_once (module Backend) result);
+  Train.printf_tree result

--- a/test/operations/test_where_precision.ml
+++ b/test/operations/test_where_precision.ml
@@ -21,6 +21,7 @@ let () =
   Tn.update_prec else_val.value Ir.Ops.bfloat16;
   (* else branch is bfloat16 *)
   Tn.update_prec result.value Ir.Ops.single;
+
   (* result is single *)
 
   (* Initialize on host (rather than on device). *)

--- a/test/operations/test_where_precision.ml
+++ b/test/operations/test_where_precision.ml
@@ -21,10 +21,13 @@ let () =
   Tn.update_prec else_val.value Ir.Ops.bfloat16;
   (* else branch is bfloat16 *)
   Tn.update_prec result.value Ir.Ops.single;
-
   (* result is single *)
 
+  (* Initialize on host (rather than on device). *)
+  Tn.set_values cond.value [| 0.0 |];
+  Tn.set_values a.value [| 1.0 |];
+  Tn.set_values b.value [| 2.0 |];
+
   (* Set up values and run computation *)
-  Train.set_hosted result.value;
   ignore (Train.forward_once (module Backend) result);
   Train.printf_tree result

--- a/test/operations/test_where_precision.ml
+++ b/test/operations/test_where_precision.ml
@@ -7,19 +7,23 @@ module Tn = Ir.Tnode
 let () =
   Tensor.unsafe_reinitialize ();
   let module Backend = (val Backends.fresh_backend ()) in
-  
   (* Test heterogeneous precision in where operation using %cd syntax *)
   let%cd condition = { cond } in
-  let%cd then_val = { a } in  
+  let%cd then_val = { a } in
   let%cd else_val = { b } in
   let%cd result = where condition then_val else_val in
-  
+
   (* Set different precisions for each argument *)
-  Tn.update_prec condition.value Ir.Ops.byte;  (* condition uses byte precision *)
-  Tn.update_prec then_val.value Ir.Ops.half;            (* then branch is half *)
-  Tn.update_prec else_val.value Ir.Ops.bfloat16;        (* else branch is bfloat16 *)
-  Tn.update_prec result.value Ir.Ops.single;            (* result is single *)
-  
+  Tn.update_prec condition.value Ir.Ops.byte;
+  (* condition uses byte precision *)
+  Tn.update_prec then_val.value Ir.Ops.half;
+  (* then branch is half *)
+  Tn.update_prec else_val.value Ir.Ops.bfloat16;
+  (* else branch is bfloat16 *)
+  Tn.update_prec result.value Ir.Ops.single;
+
+  (* result is single *)
+
   (* Set up values and run computation *)
   Train.set_hosted result.value;
   ignore (Train.forward_once (module Backend) result);


### PR DESCRIPTION
## Summary

- Support heterogeneous precision for primitive operations by extending scalar arguments with precision information
- Enhance precision handling in low-level operations with proper type conversion logic
- Add helper functions for precision classification (homogeneous vs heterogeneous operations)

## Key Changes

- **Enhanced scalar operations**: Scalar arguments now carry precision information alongside values
- **Precision-aware code generation**: Operations can now handle arguments with different precisions correctly
- **Improved type conversion**: Added proper conversion logic for mixed-precision operations like `Where` 
- **Better precision handling**: Operations like `Uint4x32_to_prec_uniform1` maintain their required argument precision

## Test plan

- [ ] Run existing test suite to ensure backward compatibility
- [ ] Test mixed-precision operations across different backends (CPU, CUDA, Metal)
- [ ] Verify generated code handles precision conversions correctly
- [ ] Test edge cases with heterogeneous precision operations

🤖 Generated with [Claude Code](https://claude.ai/code)