### PR TITLE
Replace row_id with provenance and support deduplication

### DIFF
--- a/docs/shape_inference.md
+++ b/docs/shape_inference.md
@@ -32,7 +32,7 @@ type bcast =
   | Row_var of row_var  (** The row can be inferred to have more axes. *)
   | Broadcastable  (** The shape does not have more axes of this kind, but is "polymorphic". *)
 
-type row = Row.t = { dims : dim list; bcast : bcast; id : row_id }
+type row = Row.t = { dims : dim list; bcast : bcast; id : provenance }
 
 type shape = Shape.t = {
   mutable batch : row;

--- a/tensor/row.mli
+++ b/tensor/row.mli
@@ -42,10 +42,11 @@ type print_style = Only_labels | Axis_size | Axis_number_and_size | Projection_a
 val solved_dim_to_string : print_style -> solved_dim -> string
 val dim_to_string : print_style -> dim -> string
 
-type row_id [@@deriving sexp, compare, equal, hash]
+type provenance [@@deriving sexp, compare, equal, hash]
 type row_cmp
 
-val row_id : sh_id:int -> kind:kind -> row_id
+val provenance : sh_id:int -> kind:kind -> provenance
+val merge_provenance : provenance -> provenance -> provenance
 
 type row_var [@@deriving sexp, compare, equal, hash]
 
@@ -59,10 +60,10 @@ type bcast =
   | Broadcastable  (** The shape does not have more axes of this kind, but is "polymorphic". *)
 [@@deriving equal, hash, compare, sexp, variants]
 
-type t = { dims : dim list; bcast : bcast; id : row_id } [@@deriving equal, hash, compare, sexp]
+type t = { dims : dim list; bcast : bcast; id : provenance } [@@deriving equal, hash, compare, sexp]
 
 val dims_label_assoc : t -> (string * dim) list
-val get_row_for_var : ?row_id:row_id -> row_var -> t
+val get_row_for_var : ?provenance:provenance -> row_var -> t
 
 type environment [@@deriving sexp_of]
 

--- a/tensor/row.mli
+++ b/tensor/row.mli
@@ -43,7 +43,6 @@ val solved_dim_to_string : print_style -> solved_dim -> string
 val dim_to_string : print_style -> dim -> string
 
 type provenance [@@deriving sexp, compare, equal, hash]
-type row_cmp
 
 val provenance : sh_id:int -> kind:kind -> provenance
 val merge_provenance : provenance -> provenance -> provenance
@@ -60,10 +59,10 @@ type bcast =
   | Broadcastable  (** The shape does not have more axes of this kind, but is "polymorphic". *)
 [@@deriving equal, hash, compare, sexp, variants]
 
-type t = { dims : dim list; bcast : bcast; id : provenance } [@@deriving equal, hash, compare, sexp]
+type t = { dims : dim list; bcast : bcast; prov : provenance } [@@deriving equal, hash, compare, sexp]
 
 val dims_label_assoc : t -> (string * dim) list
-val get_row_for_var : ?provenance:provenance -> row_var -> t
+val get_row_for_var : ?prov:provenance -> row_var -> t
 
 type environment [@@deriving sexp_of]
 

--- a/tensor/shape.ml
+++ b/tensor/shape.ml
@@ -363,7 +363,7 @@ let axes_spec_to_dims_bio ~sh_id ~row_var_env ~dim_var_env:_ ~f labels =
   in
   let to_row kind v dims beg_dims =
     let bcast, beg_dims = to_bcast kind v beg_dims in
-    { Row.dims = beg_dims @ to_dim kind dims; bcast; id = Row.row_id ~sh_id ~kind }
+    { Row.dims = beg_dims @ to_dim kind dims; bcast; id = Row.provenance ~sh_id ~kind }
   in
   let batch = to_row `Batch labels.bcast_batch b_dims beg_b_dims in
   let input = to_row `Input labels.bcast_input i_dims beg_i_dims in
@@ -826,13 +826,13 @@ let%debug4_sexp get_inequalities ({ shape = cur_sh; logic; id = _ } as _upd : up
             {
               dims = slice_var :: cur_sh.batch.dims;
               bcast = cur_sh.batch.bcast;
-              id = Row.row_id ~sh_id:cur_sh.id ~kind:`Batch;
+              id = Row.provenance ~sh_id:cur_sh.id ~kind:`Batch;
             }
         | Row_var { v; beg_dims } ->
             {
               dims = cur_sh.batch.dims;
               bcast = Row_var { v; beg_dims = slice_var :: beg_dims };
-              id = Row.row_id ~sh_id:cur_sh.id ~kind:`Batch;
+              id = Row.provenance ~sh_id:cur_sh.id ~kind:`Batch;
             }
       in
       let get_origin kind =
@@ -1265,7 +1265,7 @@ let set_dim delayed_var_ref dim =
       active_constraints :=
         Row.Rows_constr
           {
-            (* TODO: actually, the Row.row_id should be the one of the shape that the row variable
+            (* TODO: actually, the Row.provenance should be the one of the shape that the row variable
                is in, should be stored in `Row and in env_row_var. *)
             r = [ Row.get_row_for_var row_var ];
             constr = Total_elems { numerator = Num_elems dim; divided_by = [] };
@@ -1693,21 +1693,21 @@ let make ?batch_dims ?input_dims ?output_dims ?batch_axes ?input_axes ?output_ax
     {
       dims = List.map ~f:(fun d -> get_dim ~d ()) ds;
       bcast = Broadcastable;
-      id = row_id ~sh_id:id ~kind;
+      id = provenance ~sh_id:id ~kind;
     }
   in
   let make_axes kind ds =
     {
       dims = List.map ~f:(fun (label, d) -> get_dim ~d ~label ()) ds;
       bcast = Broadcastable;
-      id = row_id ~sh_id:id ~kind;
+      id = provenance ~sh_id:id ~kind;
     }
   in
   let make_unknown kind =
     {
       dims = [];
       bcast = Row_var { v = get_row_var (); beg_dims = [] };
-      id = row_id ~sh_id:id ~kind;
+      id = provenance ~sh_id:id ~kind;
     }
   in
   let batch =

--- a/test/einsum/test_print_style.ml
+++ b/test/einsum/test_print_style.ml
@@ -10,7 +10,7 @@ let test_print_styles () =
     {
       dims = [ get_dim ~d:32 ~label:"width" () ];
       bcast = Broadcastable;
-      id = row_id ~sh_id:1 ~kind:`Output;
+      id = provenance ~sh_id:1 ~kind:`Output;
     }
   in
   let row_with_proj = fresh_row_proj row_with_dim in

--- a/test/einsum/test_print_style.ml
+++ b/test/einsum/test_print_style.ml
@@ -10,7 +10,7 @@ let test_print_styles () =
     {
       dims = [ get_dim ~d:32 ~label:"width" () ];
       bcast = Broadcastable;
-      id = provenance ~sh_id:1 ~kind:`Output;
+      prov = provenance ~sh_id:1 ~kind:`Output;
     }
   in
   let row_with_proj = fresh_row_proj row_with_dim in

--- a/test/operations/transformer_test.expected
+++ b/test/operations/transformer_test.expected
@@ -6,8 +6,10 @@ Output shape:
   ((dims
     ((Dim ((d 2) (label ()) (proj_id ((Proj_id 2194)))))
      (Dim ((d 8) (label ()) (proj_id ((Proj_id 2195)))))))
-   (bcast Broadcastable) (id ((sh_id 830) (kind Batch)))))
- (input ((dims ()) (bcast Broadcastable) (id ((sh_id 830) (kind Input)))))
- (output ((dims ()) (bcast Broadcastable) (id ((sh_id 830) (kind Output)))))
+   (bcast Broadcastable) (prov (((sh_id 830) (kind Batch))))))
+ (input
+  ((dims ()) (bcast Broadcastable) (prov (((sh_id 830) (kind Input))))))
+ (output
+  ((dims ()) (bcast Broadcastable) (prov (((sh_id 830) (kind Output))))))
  (batch_padding ()) (input_padding ()) (output_padding ()) (id 830)
  (debug_name transformer))


### PR DESCRIPTION
Fixes #395

This PR refactors `row_id` to `provenance` throughout the codebase to make it clear that it's not intended as a key. The provenance type now stores a deduplicated list of origins instead of a single origin, enabling proper tracking when rows are merged.

## Changes
- Renamed `row_id` type to `provenance`
- Changed provenance from single record to list of `ProvenanceOrigin.t`
- Added `merge_provenance` function for combining and deduplicating origins
- Updated all pattern matches to work with new list-based structure

Generated with [Claude Code](https://claude.ai/code)