### PR TITLE
Rename kernel params from param/params to kparam/kparams

### DIFF
--- a/arrayjit/lib/backend_intf.ml
+++ b/arrayjit/lib/backend_intf.ml
@@ -41,10 +41,10 @@ type config = Only_devices_parallel | For_parallel_copying | Most_parallel_strea
 
 type merge_buffer_use = No | Streaming_for of Task.t | Copy [@@deriving sexp_of]
 
-type param_source =
+type kparam_source =
   | Log_file_name
   | Merge_buffer
-  | Param_ptr of Tnode.t
+  | Kparam_ptr of Tnode.t
   | Static_idx of Indexing.static_symbol
 [@@deriving sexp_of]
 

--- a/arrayjit/lib/c_syntax.ml
+++ b/arrayjit/lib/c_syntax.ml
@@ -754,11 +754,11 @@ module C_syntax (B : C_syntax_config) = struct
   let compile_main llc : PPrint.document = pp_ll llc
 
   let compile_proc ~name idx_params Low_level.{ traced_store; llc; merge_node; optimize_ctx = _ } :
-      (string * param_source) list * PPrint.document =
+      (string * kparam_source) list * PPrint.document =
     let open PPrint in
-    let params : (string * param_source) list =
+    let kparams : (string * kparam_source) list =
       List.rev
-      @@ Hashtbl.fold traced_store ~init:[] ~f:(fun ~key:tn ~data:_ params ->
+      @@ Hashtbl.fold traced_store ~init:[] ~f:(fun ~key:tn ~data:_ kparams ->
           let backend_info, is_param =
             if Tn.is_virtual_force tn 334 then ("Virt", false)
             else if in_ctx tn then ("Ctx", true)
@@ -770,8 +770,8 @@ module C_syntax (B : C_syntax_config) = struct
           if not @@ Utils.sexp_mem ~elem:backend_info tn.backend_info then
             tn.backend_info <- Utils.sexp_append ~elem:backend_info tn.backend_info;
           if is_param then
-            (B.typ_of_prec (Lazy.force tn.Tn.prec) ^ " *" ^ get_ident tn, Param_ptr tn) :: params
-          else params)
+            (B.typ_of_prec (Lazy.force tn.Tn.prec) ^ " *" ^ get_ident tn, Kparam_ptr tn) :: kparams
+          else kparams)
     in
     let idx_params =
       List.map idx_params ~f:(fun s ->
@@ -790,7 +790,7 @@ module C_syntax (B : C_syntax_config) = struct
         @@ map merge_node ~f:(fun tn ->
             ("const " ^ B.typ_of_prec (Lazy.force tn.prec) ^ " *merge_buffer", Merge_buffer)))
     in
-    let all_params = log_file_param @ merge_param @ idx_params @ params in
+    let all_params = log_file_param @ merge_param @ idx_params @ kparams in
     let sorted_params =
       List.sort all_params ~compare:(fun (p1_name, _) (p2_name, _) ->
           compare_string p1_name p2_name)
@@ -841,7 +841,7 @@ module C_syntax (B : C_syntax_config) = struct
                       ~base_message_literal:base_msg
                       ~args_docs:[ string @@ "(" ^ B.buffer_prefix ^ "void*)merge_buffer" ]
                 | Log_file_name -> empty (* Already handled by fopen or if it's just an ID *)
-                | Param_ptr tn ->
+                | Kparam_ptr tn ->
                     let base_msg =
                       Printf.sprintf "%s &[%d] = %%p\n" p_name_and_type (Tnode.num_elems tn)
                     in

--- a/arrayjit/lib/cc_backend.ml
+++ b/arrayjit/lib/cc_backend.ml
@@ -48,7 +48,7 @@ type procedure = {
   bindings : Indexing.unit_bindings;
   name : string;
   result : library;
-  params : (string * param_source) list;
+  kparams : (string * kparam_source) list;
 }
 [@@deriving sexp_of]
 
@@ -329,7 +329,7 @@ let%diagn_sexp compile ~(name : string) bindings (lowered : Low_level.optimized)
   end)) in
   let idx_params = Indexing.bound_symbols bindings in
   let build_file = Utils.open_build_file ~base_name:name ~extension:".c" in
-  let params, proc_doc = Syntax.compile_proc ~name idx_params lowered in
+  let kparams, proc_doc = Syntax.compile_proc ~name idx_params lowered in
   let filtered_code =
     Syntax.filter_and_prepend_builtins ~includes:Builtins_cc.includes ~builtins:Builtins_cc.builtins
       ~proc_doc
@@ -340,7 +340,7 @@ let%diagn_sexp compile ~(name : string) bindings (lowered : Low_level.optimized)
 
   (* let result = c_compile_and_load ~f_name:pp_file.f_name in *)
   let result_library = c_compile_and_load ~f_path:build_file.f_path in
-  { result = result_library; params; bindings; name }
+  { result = result_library; kparams; bindings; name }
 
 let%diagn_sexp compile_batch ~names bindings (lowereds : Low_level.optimized option array) :
     procedure option array =
@@ -371,8 +371,8 @@ let%diagn_sexp compile_batch ~names bindings (lowereds : Low_level.optimized opt
   let result_library = c_compile_and_load ~f_path:build_file.f_path in
   (* Note: for simplicity, we share ctx_arrays across all contexts. *)
   Array.mapi params_and_docs ~f:(fun i opt_params_and_doc ->
-      Option.bind opt_params_and_doc ~f:(fun (params, _doc) ->
-          Option.map names.(i) ~f:(fun name -> { result = result_library; params; bindings; name })))
+      Option.bind opt_params_and_doc ~f:(fun (kparams, _doc) ->
+          Option.map names.(i) ~f:(fun name -> { result = result_library; kparams; bindings; name })))
 
 let%track3_sexp link_compiled ~merge_buffer ~runner_label ctx_arrays (code : procedure) =
   let name : string = code.name in
@@ -383,11 +383,11 @@ let%track3_sexp link_compiled ~merge_buffer ~runner_label ctx_arrays (code : pro
       let rec link :
           'a 'b 'idcs.
           'idcs Indexing.bindings ->
-          param_source list ->
+          kparam_source list ->
           ('a -> 'b) Ctypes.fn ->
           ('a -> 'b, 'idcs, 'p1, 'p2) Indexing.variadic =
-       fun (type a b idcs) (binds : idcs Indexing.bindings) params (cs : (a -> b) Ctypes.fn) ->
-        match (binds, params) with
+       fun (type a b idcs) (binds : idcs Indexing.bindings) kparams (cs : (a -> b) Ctypes.fn) ->
+        match (binds, kparams) with
         | Empty, [] -> Indexing.Result (Foreign.foreign ~from:code.result.lib name cs)
         | Bind _, [] -> invalid_arg "Cc_backend.link: too few static index params"
         | Bind (_, bs), Static_idx _ :: ps -> Param_idx (ref 0, link bs ps Ctypes.(int @-> cs))
@@ -397,7 +397,7 @@ let%track3_sexp link_compiled ~merge_buffer ~runner_label ctx_arrays (code : pro
         | bs, Merge_buffer :: ps ->
             let get_ptr buf = buf.ptr in
             Param_2f (get_ptr, merge_buffer, link bs ps Ctypes.(ptr void @-> cs))
-        | bs, Param_ptr tn :: ps ->
+        | bs, Kparam_ptr tn :: ps ->
             let c_ptr =
               match Map.find ctx_arrays tn with
               | None ->
@@ -415,8 +415,8 @@ let%track3_sexp link_compiled ~merge_buffer ~runner_label ctx_arrays (code : pro
       (* Reverse the input order because [Indexing.apply] will reverse it again. Important:
          [code.bindings] are traversed in the wrong order but that's OK because [link] only uses
          them to check the number of indices. *)
-      let params = List.rev_map code.params ~f:(fun (_, p) -> p) in
-      link code.bindings params Ctypes.(void @-> returning void)]
+      let kparams = List.rev_map code.kparams ~f:(fun (_, p) -> p) in
+      link code.bindings kparams Ctypes.(void @-> returning void)]
   in
   let%diagn_sexp work () : unit =
     [%log_result name];

--- a/arrayjit/lib/cuda_backend.ml
+++ b/arrayjit/lib/cuda_backend.ml
@@ -295,7 +295,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
   type code = {
     traced_store : Low_level.traced_store;
     ptx : Nvrtc.compile_to_ptx_result;
-    params : (string * param_source) list;
+    kparams : (string * kparam_source) list;
     bindings : Indexing.unit_bindings;
     name : string;
   }
@@ -305,7 +305,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     traced_stores : Low_level.traced_store option array;
     ptx : Nvrtc.compile_to_ptx_result;
     bindings : Indexing.unit_bindings;
-    params_and_names : ((string * param_source) list * string) option array;
+    kparams_and_names : ((string * kparam_source) list * string) option array;
   }
   [@@deriving sexp_of]
 
@@ -850,7 +850,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
       let procs = [| lowered |]
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
-    let params, proc_doc = Syntax.compile_proc ~name idx_params lowered in
+    let kparams, proc_doc = Syntax.compile_proc ~name idx_params lowered in
     let cuda_includes =
       {|#include <cuda_fp16.h>
 #include <cuda_bf16.h>
@@ -872,21 +872,21 @@ end) : Ir.Backend_impl.Lowered_backend = struct
         ~proc_doc
     in
     let ptx = cuda_to_ptx ~name source in
-    { traced_store; ptx; params; bindings; name }
+    { traced_store; ptx; kparams; bindings; name }
 
   let%diagn2_sexp compile_batch ~names bindings lowereds =
     let module Syntax = C_syntax.C_syntax (Cuda_syntax_config (struct
       let procs = Array.filter_opt lowereds
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
-    let params_and_docs =
+    let kparams_and_docs =
       Array.map2_exn names lowereds
         ~f:
           (Option.map2 ~f:(fun name lowered ->
-               let params, doc = Syntax.compile_proc ~name idx_params lowered in
-               ((params, name), doc)))
+               let kparams, doc = Syntax.compile_proc ~name idx_params lowered in
+               ((kparams, name), doc)))
     in
-    let all_proc_docs = List.filter_map (Array.to_list params_and_docs) ~f:(Option.map ~f:snd) in
+    let all_proc_docs = List.filter_map (Array.to_list kparams_and_docs) ~f:(Option.map ~f:snd) in
     let final_doc = PPrint.(separate hardline all_proc_docs) in
     let cuda_includes =
       {|#include <cuda_fp16.h>
@@ -916,8 +916,8 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     in
     let ptx = cuda_to_ptx ~name source in
     let traced_stores = Array.map lowereds ~f:(Option.map ~f:(fun l -> l.Low_level.traced_store)) in
-    let params_and_names = Array.map params_and_docs ~f:(Option.map ~f:fst) in
-    { traced_stores; ptx; params_and_names; bindings }
+    let kparams_and_names = Array.map kparams_and_docs ~f:(Option.map ~f:fst) in
+    { traced_stores; ptx; kparams_and_names; bindings }
 
   let get_global_run_id =
     let next_id = ref 0 in
@@ -926,7 +926,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
       if !next_id < 0 then next_id := 0;
       !next_id
 
-  let link_proc ~prior_context ~name ~(params : (string * param_source) list) ~ctx_arrays
+  let link_proc ~prior_context ~name ~(kparams : (string * kparam_source) list) ~ctx_arrays
       lowered_bindings run_module =
     let func = Cu.Module.get_function run_module ~name in
     let stream = prior_context.stream in
@@ -940,13 +940,13 @@ end) : Ir.Backend_impl.Lowered_backend = struct
         "on",
         stream_name,
         (log_id : int),
-        (params : (string * param_source) list)];
+        (kparams : (string * kparam_source) list)];
       let module S = Cu.Stream in
       let args : S.kernel_param list =
         (* TODO: should we prohibit or warn about local-only tensors that are in
            prior_context.ctx_arrays? *)
-        List.map params ~f:(function
-          | _name, Param_ptr tn ->
+        List.map kparams ~f:(function
+          | _name, Kparam_ptr tn ->
               let arr = Option.value_exn ~here:[%here] @@ Map.find ctx_arrays tn in
               S.Tensor arr
           | _name, Log_file_name -> S.Int log_id
@@ -996,7 +996,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
       List.map idx_params ~f:(fun s -> (s, ref 0))
     in
     let task =
-      link_proc ~prior_context ~name:code.name ~params:code.params ~ctx_arrays lowered_bindings
+      link_proc ~prior_context ~name:code.name ~kparams:code.kparams ~ctx_arrays lowered_bindings
         run_module
     in
     (lowered_bindings, task)
@@ -1011,11 +1011,11 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     let run_module = Cu.Module.load_data_ex code_batch.ptx (run_options ()) in
     prior_context.stream.device.dev.set_builtins_in run_module;
     let procs =
-      Array.mapi code_batch.params_and_names ~f:(fun i pns ->
+      Array.mapi code_batch.kparams_and_names ~f:(fun i pns ->
           Option.value ~default:None
-          @@ Option.map2 pns ctx_arrays.(i) ~f:(fun (params, name) ctx_arrays ->
+          @@ Option.map2 pns ctx_arrays.(i) ~f:(fun (kparams, name) ctx_arrays ->
               let task =
-                link_proc ~prior_context ~name ~params ~ctx_arrays lowered_bindings run_module
+                link_proc ~prior_context ~name ~kparams ~ctx_arrays lowered_bindings run_module
               in
               Some task))
     in

--- a/arrayjit/lib/metal_backend.ml
+++ b/arrayjit/lib/metal_backend.ml
@@ -401,7 +401,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     metal_source : string; (* Store source, compile during link if not already compiled *)
     compiled_code : Me.Library.t option array; (* Store compiled code per device *)
     func_name : string;
-    params : (string * param_source) list;
+    kparams : (string * kparam_source) list;
     bindings : Indexing.unit_bindings;
     traced_store : Low_level.traced_store;
   }
@@ -410,7 +410,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
   type code_batch = {
     metal_source : string; (* Store combined source *)
     compiled_code : Me.Library.t option array; (* Store compiled code per device *)
-    funcs : (string * (string * param_source) list) option array; (* func_name * params *)
+    funcs : (string * (string * kparam_source) list) option array; (* func_name * kparams *)
     bindings : Indexing.unit_bindings;
     traced_stores : Low_level.traced_store option array;
   }
@@ -685,7 +685,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
     (* Add Metal address space qualifiers *)
-    let params, proc_doc = Syntax.compile_proc ~name idx_params lowered in
+    let kparams, proc_doc = Syntax.compile_proc ~name idx_params lowered in
     let metal_includes = {|#include <metal_stdlib>
 using namespace metal;|} in
     let source =
@@ -697,7 +697,7 @@ using namespace metal;|} in
       compiled_code = Array.create ~len:num_devs None;
       (* One slot per device *)
       func_name = name;
-      params;
+      kparams;
       bindings;
       traced_store = lowered.traced_store;
     }
@@ -711,8 +711,8 @@ using namespace metal;|} in
       Array.map2_exn names lowereds
         ~f:
           (Option.map2 ~f:(fun name lowered ->
-               let params, doc = Syntax.compile_proc ~name idx_params lowered in
-               ((name, params), doc)))
+               let kparams, doc = Syntax.compile_proc ~name idx_params lowered in
+               ((name, kparams), doc)))
     in
     let all_proc_docs = List.filter_map (Array.to_list funcs_and_docs) ~f:(Option.map ~f:snd) in
     let final_doc = PPrint.(separate hardline all_proc_docs) in
@@ -734,7 +734,7 @@ using namespace metal;|} in
     }
 
   let%debug4_sexp link_proc ~prior_context ~library ~func_name
-      ~(params : (string * param_source) list) ~lowered_bindings ~(ctx_arrays : buffer_ptr Tn.t_map)
+      ~(kparams : (string * kparam_source) list) ~lowered_bindings ~(ctx_arrays : buffer_ptr Tn.t_map)
       : Task.t =
     let stream = prior_context.stream in
     let device = stream.device.dev in
@@ -754,12 +754,12 @@ using namespace metal;|} in
         Me.ComputeCommandEncoder.set_compute_pipeline_state encoder pso;
 
         (* Set arguments *)
-        List.iteri params ~f:(fun index (_p_name, p_source) ->
+        List.iteri kparams ~f:(fun index (_p_name, p_source) ->
             match p_source with
-            | Param_ptr tn when Map.mem ctx_arrays tn ->
+            | Kparam_ptr tn when Map.mem ctx_arrays tn ->
                 let buffer = Map.find_exn ctx_arrays tn in
                 Me.ComputeCommandEncoder.set_buffer encoder ~index buffer
-            | Param_ptr tn when Tn.known_constant tn && Tn.is_hosted_force tn 48 ->
+            | Kparam_ptr tn when Tn.known_constant tn && Tn.is_hosted_force tn 48 ->
                 let buffer =
                   Hashtbl.find_or_add stream.device.cross_stream_candidates tn ~default:(fun () ->
                       get_buffer_for_ptr device ~size_in_bytes:(Lazy.force tn.size_in_bytes)
@@ -768,9 +768,9 @@ using namespace metal;|} in
                       @@ Lazy.force tn.array)
                 in
                 Me.ComputeCommandEncoder.set_buffer encoder ~index buffer
-            | Param_ptr tn ->
+            | Kparam_ptr tn ->
                 failwith
-                  [%string "Param_ptr %{Tn.debug_name tn} not found in ctx_arrays for %{func_name}"]
+                  [%string "Kparam_ptr %{Tn.debug_name tn} not found in ctx_arrays for %{func_name}"]
             | Static_idx s ->
                 let value = !(Indexing.find_exn lowered_bindings s) in
                 let size = Ctypes.sizeof Ctypes.int in
@@ -817,7 +817,7 @@ using namespace metal;|} in
       List.map (Indexing.bound_symbols code.bindings) ~f:(fun s -> (s, ref 0))
     in
     let task =
-      link_proc ~prior_context ~library ~func_name:code.func_name ~params:code.params
+      link_proc ~prior_context ~library ~func_name:code.func_name ~kparams:code.kparams
         ~lowered_bindings ~ctx_arrays
     in
     (lowered_bindings, task)
@@ -831,9 +831,9 @@ using namespace metal;|} in
 
     let tasks =
       Array.mapi code_batch.funcs ~f:(fun i func_opt ->
-          Option.bind func_opt ~f:(fun (func_name, params) ->
+          Option.bind func_opt ~f:(fun (func_name, kparams) ->
               Option.map ctx_arrays_opts.(i) ~f:(fun ctx_arrays ->
-                  link_proc ~prior_context ~library ~func_name ~params ~lowered_bindings ~ctx_arrays)))
+                  link_proc ~prior_context ~library ~func_name ~kparams ~lowered_bindings ~ctx_arrays)))
     in
     (lowered_bindings, tasks)
 end


### PR DESCRIPTION
## Summary
- Renames `param_source` → `kparam_source` and `Param_ptr` → `Kparam_ptr` in `backend_intf.ml`
- Renames `procedure.params` → `procedure.kparams` in all backend files (cc, cuda, metal)
- Renames `code_batch.params_and_names` → `kparams_and_names` in `cuda_backend.ml`
- All local bindings, function signatures, and pattern matches updated consistently
- `Tensor.params` and all tensor-layer naming remains unchanged

Closes #356

## Test plan
- [x] Project compiles cleanly (`dune build @check`)
- [x] No remaining references to old `param_source` / `Param_ptr` in `.ml` files
- [x] `Tensor.params` unchanged
- [x] Test suite passes (`dune runtest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)