### PR TITLE
Fix build_files/ sharing between test executables

### DIFF
--- a/arrayjit/lib/utils.ml
+++ b/arrayjit/lib/utils.ml
@@ -247,11 +247,13 @@ let diagn_log_file fname =
 
 let () =
   (* Cleanup needs to happen before get_local_debug_runtime (or any other code is run). *)
-  let remove_dir_if_exists dirname =
+  let rec remove_dir_if_exists dirname =
     if Stdlib.Sys.file_exists dirname && Stdlib.Sys.is_directory dirname then
       try
         Array.iter (Stdlib.Sys.readdir dirname) ~f:(fun fname ->
-            Stdlib.Sys.remove (Stdlib.Filename.concat dirname fname));
+            let path = Stdlib.Filename.concat dirname fname in
+            if Stdlib.Sys.is_directory path then remove_dir_if_exists path
+            else Stdlib.Sys.remove path);
         Stdlib.Sys.rmdir dirname
       with exn ->
         Stdio.eprintf "Failed to delete directory %s: %s\n%!" dirname (Exn.to_string exn)

--- a/arrayjit/lib/utils.ml
+++ b/arrayjit/lib/utils.ml
@@ -225,9 +225,16 @@ let clean_filename fname =
   fname
 
 let build_file fname =
-  let build_files_dir = "build_files" in
+  let prefix = get_global_arg ~default:"" ~arg_name:"build_files_prefix" in
+  let build_files_dir =
+    if String.is_empty prefix then "build_files"
+    else filename_concat "build_files" (clean_filename prefix)
+  in
   (try assert (Stdlib.Sys.is_directory build_files_dir)
-   with Stdlib.Sys_error _ -> Stdlib.Sys.mkdir build_files_dir 0o777);
+   with Stdlib.Sys_error _ | Assert_failure _ ->
+     (try assert (Stdlib.Sys.is_directory "build_files")
+      with Stdlib.Sys_error _ | Assert_failure _ -> Stdlib.Sys.mkdir "build_files" 0o777);
+     if not (String.is_empty prefix) then Stdlib.Sys.mkdir build_files_dir 0o777);
   filename_concat build_files_dir @@ clean_filename fname
 
 let diagn_log_file fname =
@@ -261,7 +268,10 @@ let () =
   let clean_up_build_files_on_startup =
     get_global_flag ~default:true ~arg_name:"clean_up_build_files_on_startup"
   in
-  if clean_up_build_files_on_startup then remove_dir_if_exists "build_files"
+  if clean_up_build_files_on_startup then (
+    let prefix = get_global_arg ~default:"" ~arg_name:"build_files_prefix" in
+    if String.is_empty prefix then remove_dir_if_exists "build_files"
+    else remove_dir_if_exists (filename_concat "build_files" (clean_filename prefix)))
 
 let get_local_debug_runtime =
   let snapshot_every_sec =

--- a/ocannl_config.example
+++ b/ocannl_config.example
@@ -57,7 +57,13 @@ automatic_host_transfers=true
 # Set to true for models with tensors larger than 2^32 elements.
 big_models=false
 
+# If non-empty, generated code files are placed in build_files/<prefix>/ instead of
+# build_files/. This prevents filename collisions when multiple test executables run
+# in parallel. Each test should use a unique prefix (typically its executable name).
+build_files_prefix=
+
 # If true, the build_files directory is deleted on startup.
+# When build_files_prefix is set, only the specific prefix subdirectory is deleted.
 clean_up_build_files_on_startup=true
 
 # If true, the log_files directory is deleted on startup.

--- a/test/einsum/dune
+++ b/test/einsum/dune
@@ -101,8 +101,9 @@
    (progn
     (run
      %{dep:inline_permuted_view.exe}
-     "--ocannl_output_debug_files_in_build_directory=true")
-    (copy build_files/c_fwd.ll %{target})))))
+     "--ocannl_output_debug_files_in_build_directory=true"
+     "--ocannl_build_files_prefix=inline_permuted_view")
+    (copy build_files/inline_permuted_view/c_fwd.ll %{target})))))
 
 (rule
  (alias runtest)
@@ -135,8 +136,9 @@
    (progn
     (run
      %{dep:test_cse.exe}
-     "--ocannl_output_debug_files_in_build_directory=true")
-    (copy build_files/cse_d_fwd.ll %{target})))))
+     "--ocannl_output_debug_files_in_build_directory=true"
+     "--ocannl_build_files_prefix=test_cse")
+    (copy build_files/test_cse/cse_d_fwd.ll %{target})))))
 
 (rule
  (alias runtest)

--- a/test/operations/dune
+++ b/test/operations/dune
@@ -129,8 +129,9 @@
     (run
      %{dep:threefry4x32_demo.exe}
      "--ocannl_output_prec_in_ll_files=true"
-     "--ocannl_output_debug_files_in_build_directory=true")
-    (copy build_files/n3_fwd-unoptimized.ll %{target})))))
+     "--ocannl_output_debug_files_in_build_directory=true"
+     "--ocannl_build_files_prefix=threefry4x32_demo")
+    (copy build_files/threefry4x32_demo/n3_fwd-unoptimized.ll %{target})))))
 
 (rule
  (targets top_down_prec-unoptimized.ll.actual top_down_prec.extension.actual)
@@ -145,12 +146,13 @@
     (run
      %{dep:top_down_prec.exe}
      "--ocannl_output_prec_in_ll_files=true"
-     "--ocannl_output_debug_files_in_build_directory=true")
+     "--ocannl_output_debug_files_in_build_directory=true"
+     "--ocannl_build_files_prefix=top_down_prec")
     (copy
-     build_files/d_fwd-unoptimized.ll
+     build_files/top_down_prec/d_fwd-unoptimized.ll
      top_down_prec-unoptimized.ll.actual)
     (copy
-     build_files/d_fwd.%{read:config/ocannl_backend_extension.txt}
+     build_files/top_down_prec/d_fwd.%{read:config/ocannl_backend_extension.txt}
      top_down_prec.extension.actual)))))
 
 (rule
@@ -168,12 +170,13 @@
     (run
      %{dep:test_where_precision.exe}
      "--ocannl_output_prec_in_ll_files=true"
-     "--ocannl_output_debug_files_in_build_directory=true")
+     "--ocannl_output_debug_files_in_build_directory=true"
+     "--ocannl_build_files_prefix=test_where_precision")
     (copy
-     build_files/where_fwd-unoptimized.ll
+     build_files/test_where_precision/where_fwd-unoptimized.ll
      test_where_precision-unoptimized.ll.actual)
     (copy
-     build_files/where_fwd.%{read:config/ocannl_backend_extension.txt}
+     build_files/test_where_precision/where_fwd.%{read:config/ocannl_backend_extension.txt}
      test_where_precision.extension.actual)))))
 
 (rule


### PR DESCRIPTION
## Summary

- Add `build_files_prefix` config option so each test executable can write to an isolated `build_files/<prefix>/` subdirectory instead of the shared flat `build_files/`
- Update all 5 dune rules that copy from `build_files/` to pass `--ocannl_build_files_prefix=<test-name>` and use prefixed copy paths
- Scope `clean_up_build_files_on_startup` to only delete the prefix subdirectory when a prefix is set

Fixes parallel test execution races where multiple tests produce routines with the same name (gh-ocannl-351 follow-up item 4).

## Test plan

- [x] `dune build @check` compiles cleanly
- [x] All 5 build_files-related test rules produce correct output with prefixed paths
- [x] Tests not using `build_files/` are unaffected (default prefix is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)