### PR TITLE
gh-ocannl-57: decoder-only transformer example on Names dataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
   - Binary ops: `add`, `sub`, `pointmul`, `pointpow`, `pointdiv`, `lt`, `eq`, `ne`
   - Unary ops: `relu`, `sat01`, `exp`, `log`, `exp2`, `log2`, `sin`, `cos`, `sqrt`, `recip`, `recip_sqrt`, `tanh`, `neg`, `not`, `stop_gradient`
 - Common gotchas and idioms section in CLAUDE.md documentation
+- `decoder_only_block` and `decoder_only` building blocks in `nn_blocks.ml` for GPT-style models
+- Transformer language model example on Names dataset (`test/training/transformer_names.ml`)
 - `Rev_sides` support in lowering for reverse-direction Block operations
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See [ROADMAP.md](ROADMAP.md) for the detailed schedule. Target: **v0.9 at ICFP 2
     - [x] Handle shifting and explicit padding as special cases of concatenating with a fixed index: e.g. `1^i=>i` is shifting left by 1, and `i=>1^i` is padding on the left by 1.
   - [x] Sokoban CNN building block.
   - [ ] RoPE embeddings.
-  - [ ] Transformer for the Names dataset (bigram MLP exists, not full transformer).
+  - [x] Transformer for the Names dataset (bigram MLP exists, not full transformer).
 * **0.7.0 (End Feb 2026): Frontend finalization.** Paper-ready release for workshop submissions (OCaml Workshop, FProPer).
   - [ ] Cleanup of deprecated streams functionality.
   - [ ] Migrating from the "hosted tensor" idea to always requiring a context when accessing tensors and dealing with devices directly.

--- a/docs/proposals/centered-init-and-to-routine-context.md
+++ b/docs/proposals/centered-init-and-to-routine-context.md
@@ -1,0 +1,62 @@
+# Add centered param init support and return updated context from Train.to_routine
+
+## Goal
+
+Two improvements discovered during the Karpathy FSM transformer tutorial (gh-ocannl-116):
+
+1. Neural networks need centered parameter initialization (values in [-0.5, 0.5) or [-1, 1) rather than [0, 1)). Users who try to build centered init from existing primitives (e.g., `2 * uniform1 - 1`) inadvertently create gradient-carrying intermediate nodes that cause NaN during SGD updates, because `sgd_update` iterates over all `loss.Tensor.params` including those stale intermediates.
+
+2. `Train.to_routine` discards the updated `Context.t` returned by `Context.compile`, preventing users from threading context through multiple routine compilations that share tensor nodes.
+
+Related: gh-ocannl-116, task-28c898b7.
+
+## Acceptance Criteria
+
+1. A convenience function (e.g., `centered_uniform1`) is available in the DSL that produces uniform random values centered around zero, suitable as a drop-in `default_param_init` replacement.
+2. The centered init function does not create gradient-carrying intermediate nodes -- only the final param tensor itself should have `Require_grad`. This prevents the NaN issue when used with `sgd_update`.
+3. `Train.to_routine` returns `Context.t * Context.routine` (the updated context alongside the routine).
+4. All in-tree callers of `Train.to_routine` are updated to destructure the new return type.
+5. Existing tests pass after the changes.
+
+## Context
+
+### Centered init
+
+- `tensor/operation.ml` line 710: `default_param_init` defaults to `uniform1 ~grad_spec:Require_grad`.
+- `tensor/operation.ml` lines 632-638: `uniform1` chains `embed_self_id`, `threefry4x32`, and `uint4x32_to_prec_uniform1` -- each intermediate node inherits the passed `grad_spec`.
+- `tensor/operation.ml` lines 715-733: `param` function uses `!default_param_init ()` when no explicit init is given.
+- `lib/train.ml` lines 110-113: `sgd_update` iterates `loss.Tensor.params` and calls `sgd_one` on every param with a `diff` field, including init-time intermediates if they carry `Require_grad`.
+- The key insight: init-time arithmetic intermediates should use `Prohibit_grad`; only the outermost param tensor needs `Require_grad`.
+
+### to_routine context threading
+
+- `lib/train.ml` lines 186-203: `to_routine` calls `Context.compile ctx comp bindings` which returns `(Context.t * Context.routine)`, but discards the context with `let _ctx, routine = ...`.
+- `lib/train.ml` line 208: `init_params` already returns `Context.t` after compile+run, showing the pattern.
+- Callers that need updating (all in-tree uses of `to_routine`):
+  - `test/einsum/moons_demo_variant.ml`, `test/einsum/test_padding_reset.ml`
+  - `test/operations/test_where_simple.ml`, `test/operations/zero2hero_1of7_exec.ml`, `test/operations/test_execution_deps.ml`
+  - `test/training/bigram.ml`, `bigram_mlp.ml`, `circles_conv.ml`, `cifar_conv.ml`, `mnist_conv.ml`, `moons_demo.ml`
+  - `test/operations/primitive_ops.ml`, `check_slice_shapes.ml`
+  - `bin/compilation_speed.ml`
+
+## Approach
+
+*Suggested approach -- agents may deviate if they find a better path.*
+
+**Centered init**: Add `centered_uniform1` (and optionally `centered_uniform`) functions in `operation.ml` that build the same threefry PRNG chain as `uniform1` but with `Prohibit_grad` on all intermediate nodes, then apply `2 * result - 1` arithmetic also with `Prohibit_grad`, wrapping only the final output with the caller's `grad_spec`. Expose through `Make_DSL` alongside existing `uniform1`.
+
+**to_routine**: Change return type from `Context.routine` to `Context.t * Context.routine`. Callers that don't need the context can destructure as `let _ctx, routine = ...`.
+
+## Scope
+
+**In scope:**
+- New centered init convenience function(s) in `operation.ml` and the DSL module
+- Changing `to_routine` return type and updating all in-tree callers
+- Updating any affected `.mli` signatures
+
+**Out of scope:**
+- Changes to the IR/codegen layer or `fetch_op` type
+- Adding new PRNG variants (normal distribution centering, etc.) beyond the basic centered uniform
+- Out-of-tree caller migration (they will get a clear type error)
+
+**Dependencies:** None blocking. Related to gh-ocannl-116 (source of discovery) and task-28c898b7.

--- a/docs/proposals/cross-entropy-loss.md
+++ b/docs/proposals/cross-entropy-loss.md
@@ -1,0 +1,83 @@
+# Add Nn_blocks.cross_entropy_loss helper
+
+## Goal
+
+Cross-entropy loss from logits is reimplemented in every training example with slight variations, some numerically unstable (e.g. `log(softmax(x))` in `transformer_with_loss`). A canonical `cross_entropy_loss` helper in `Nn_blocks` eliminates this boilerplate and provides a numerically stable implementation using the log-softmax trick.
+
+## Acceptance Criteria
+
+1. `Nn_blocks.cross_entropy_loss` computes cross-entropy loss from raw logits and one-hot targets using numerically stable log-softmax (subtract max before exp).
+2. Accepts a `~spec` parameter following the same convention as `Nn_blocks.softmax` (specifies which axes are the class/vocabulary axes).
+3. Supports an optional `~mask` parameter for excluding positions (e.g. padding tokens) from the loss.
+4. Supports an optional `~normalize_by` parameter for custom normalization (e.g. valid token count instead of batch size).
+5. Without mask or normalize_by, the function returns the summed scalar loss (reduced to 0-dimensional).
+6. `transformer_with_loss` in `nn_blocks.ml` is refactored to use the new helper, fixing its current numerical instability.
+7. The function is documented with an ocamldoc comment following the style of existing helpers.
+
+## Context
+
+### Key files
+
+| File | Lines | Relevance |
+|------|-------|-----------|
+| `lib/nn_blocks.ml:98-104` | `reduce_specified_axes` | Generates reduction einsum spec from user-facing axis spec -- reuse for the new function |
+| `lib/nn_blocks.ml:107-113` | `softmax` | Existing helper whose `~spec` convention and numerical stability pattern (subtract max) should be followed |
+| `lib/nn_blocks.ml:325-338` | `transformer_with_loss` | Uses naive `log(softmax(x))` -- primary refactoring target |
+| `test/training/mnist_conv.ml:105-109` | MNIST loss | Uses `softmax + epsilon` pattern -- could optionally adopt the helper |
+| `test/training/bigram.ml:40-42` | Bigram loss | Manual softmax + NLL pattern |
+| `test/training/fsm_transformer.ml:132-133` | FSM loss | Another NLL pattern variant |
+
+### Numerical stability
+
+The existing `softmax` helper (line 107-113) already implements the subtract-max trick:
+```ocaml
+let max_vals = x_scaled @^^ spec in
+let exp_vals = exp (x_scaled - max_vals) in
+exp_vals /. (exp_vals ++ spec)
+```
+
+The `cross_entropy_loss` function should use the same approach but compute `log_probs` directly as `shifted - log_sum_exp` rather than taking `log(softmax(x))`, which loses numerical precision.
+
+### DSL patterns
+
+- `%op` functions use labeled arguments and `()` unit for parameter lifting
+- Inline parameters `{ name }` are learnable -- the loss function should NOT introduce any
+- `@^^` is max-reduce, `++` is sum-reduce, `*. ` is pointwise multiply
+- `reduce_specified_axes` converts a spec like `"...|v"` into `"...|v => ...|0"`
+
+## Approach
+
+*Suggested approach -- agents may deviate if they find a better path.*
+
+Add `cross_entropy_loss` to `lib/nn_blocks.ml` near the existing `softmax` function (around line 114):
+
+```ocaml
+let%op cross_entropy_loss ~spec ?mask ?normalize_by () ~logits ~targets =
+  let reduce_spec = reduce_specified_axes spec in
+  let max_logits = logits @^^ reduce_spec in
+  let shifted = logits - max_logits in
+  let log_sum_exp = log (exp shifted ++ reduce_spec) in
+  let log_probs = shifted - log_sum_exp in
+  let nll = neg ((targets *. log_probs) ++ reduce_spec) in
+  let masked_nll = match mask with None -> nll | Some m -> nll *. m in
+  let total = masked_nll ++ "...|... => 0" in
+  match normalize_by with None -> total | Some n -> total /. n
+```
+
+Then refactor `transformer_with_loss` to call it:
+```ocaml
+let loss = cross_entropy_loss ~spec:"... | v" () ~logits ~targets:tgt_target in
+```
+
+## Scope
+
+**In scope:**
+- New `cross_entropy_loss` function in `lib/nn_blocks.ml`
+- Refactoring `transformer_with_loss` to use it
+- Documenting the new function
+
+**Out of scope:**
+- Refactoring training examples (they serve as tutorials showing the manual pattern)
+- Label smoothing or other advanced loss variants
+- General loss function framework
+- Changes to the `softmax` function itself

--- a/docs/proposals/gh-ocannl-133.md
+++ b/docs/proposals/gh-ocannl-133.md
@@ -1,0 +1,60 @@
+# Enable Inlining for Virtual Nodes with Non-Linear Index Symbols
+
+## Goal
+
+Allow virtual node (inlining) optimization to handle tensors whose setter indices involve non-linear symbol usage: (1) multiple non-static symbols in a single `Affine` index position, and (2) the same symbol appearing at multiple index positions (diagonal tensors). Currently, these patterns trigger `Non_virtual 51` and `Non_virtual 5` respectively, forcing materialization. Diagonal tensors created via einsum (e.g., `i=>ii`) are the primary motivating case -- without inlining, they waste storage on mostly-zero elements.
+
+Tracked by: https://github.com/ahrefs/ocannl/issues/133
+
+## Acceptance Criteria
+
+- `check_idcs` in `check_and_store_virtual` accepts multi-symbol `Affine` indices (removing the `Non_virtual 51` restriction), collecting all non-static symbols from across the affine term list rather than requiring exactly one per position.
+- `check_idcs` accepts repeated symbols across index positions (removing the `Non_virtual 5` restriction), so that diagonal patterns like `[| Iterator s; Iterator s |]` are valid for virtualization.
+- `make_subst` in `inline_computation` constructs the substitution environment for multi-symbol affine indices. When a definition-site index is `Affine { symbols = [(c1, s1); (c2, s2)]; offset }` and the call-site index is also an `Affine` with the same structure, the substitution maps each `s_i` to the corresponding call-site symbol (or solves the affine relationship).
+- `make_subst` handles the diagonal case: when the same symbol `s` appears at multiple definition-site positions (e.g., positions 0 and 1 both have `Iterator s`), the call-site indices at those positions must be consistent -- if they are both `Iterator t`, the substitution `s -> Iterator t` is recorded once; if they differ, the inlining must insert a conditional guard (an `if pos0_idx = pos1_idx` branch) or the node is marked non-virtual.
+- `Fixed_idx` and `Task_id` indices in setter positions are handled: `Fixed_idx i` in a definition-site index matches the same `Fixed_idx i` at the call site (no substitution needed, already works via the `equal_axis_index` fallthrough), and the same for `Sub_axis`.
+- Existing single-symbol inlining tests pass without regression.
+- New tests cover: (a) a diagonal tensor `i=>ii` being virtualized, (b) a partially diagonal tensor where some axes share a symbol, (c) a multi-symbol affine index (e.g., convolution-style `stride*i + j`).
+
+## Context
+
+### Two blocking checks
+
+**Block 1 -- `Non_virtual 51` (line 491):** In `check_idcs`, each `Affine` index position is required to contribute at most one non-static symbol. Multi-symbol affine indices like `Affine { symbols = [(stride, i); (dilation, j)]; offset = -padding }` (convolution patterns) are rejected. The fix is to collect all symbols from all terms across the affine expression and add them to the `syms` set.
+
+**Block 2 -- `Non_virtual 5` (line 499):** After collecting symbols, `check_idcs` verifies that the count of `Iterator` positions with non-static symbols equals the set size. This is a uniqueness check: each symbol must appear at exactly one `Iterator` position. For diagonal tensors (`i=>ii`), the same symbol `s` appears at two `Iterator` positions, so `num_syms=2` but `Set.length syms=1`. The fix is to remove or relax this uniqueness assertion -- the key invariant to preserve is that all accesses to the tensor use *structurally identical* index arrays (enforced by `Non_virtual 4`).
+
+### Substitution changes in `make_subst`
+
+Currently `make_subst` (line 632) handles only `Iterator lhs_s` at each position -- one symbol per position, one substitution entry per position. For non-linear cases:
+
+1. **Multi-symbol affine:** When `lhs_ind` is `Affine { symbols = [(c1,s1); (c2,s2)]; offset }` and `rhs_ind` is `Affine { symbols = [(c1,t1); (c2,t2)]; offset' }`, the substitution should map `s1 -> Iterator t1` and `s2 -> Iterator t2` (assuming matching coefficients). If the call-site structure differs, solving is needed or the node stays non-virtual.
+
+2. **Repeated symbol (diagonal):** When position 0 has `Iterator s` and position 1 also has `Iterator s`, `make_subst` at position 0 produces `(s, rhs0)` and at position 1 produces `(s, rhs1)`. If `rhs0 = rhs1`, the substitution is consistent. If `rhs0 != rhs1`, the inlining must wrap the computation in a guard `if rhs0 = rhs1 then <computation> else 0.0` -- this is the "partial inlining" case described in the issue.
+
+### Key code locations
+
+- **Validation:** `arrayjit/lib/low_level.ml`, `check_and_store_virtual` / `check_idcs` (lines 457-500)
+- **Inlining:** `arrayjit/lib/low_level.ml`, `inline_computation` / `make_subst` (lines 623-710)
+- **Substitution engine:** `arrayjit/lib/low_level.ml`, `subst` function (lines 655-686) -- already handles nested `Affine` expansion correctly
+- **Index types:** `arrayjit/lib/indexing.ml`, `axis_index` type (line 104)
+- **Diagonal tensor test patterns:** `test/einsum/test_surjectivity.ml`, `test/einsum/test_accumulation_semantics.ml`
+- **Documentation:** `docs/lowering_and_inlining.md` (lines 282-297 describe the current limitation)
+
+### Approach sketch
+
+1. **Relax `check_idcs`:** Replace the `Non_virtual 51` branch with symbol collection from all affine terms. Remove the `Non_virtual 5` uniqueness check (the structural equality check at `Non_virtual 4` is sufficient to ensure consistency across accesses).
+
+2. **Extend `make_subst` for multi-symbol affine:** When both LHS and RHS are `Affine` with matching coefficient structure, produce one substitution entry per symbol pair. When structures don't match, raise `Non_virtual 13`.
+
+3. **Extend `make_subst` for repeated symbols:** Return a list of `(symbol, axis_index)` pairs per position. After collecting all pairs, check consistency: if the same symbol maps to different call-site indices, either (a) insert an equality guard in the inlined code (`if idx_a = idx_b then ... else 0.0`), or (b) reject as non-virtual. Option (a) is the full solution for partial diagonals; option (b) is a conservative first step that still handles the case where the caller also uses the same symbol at both positions.
+
+4. **Add guard insertion to `inline_computation`:** For the diagonal case with inconsistent call-site indices, wrap the inlined `Set_local` in a conditional. This requires adding a `Cond`-like construct at the LLC scalar level, or using the existing `Binop` with appropriate semantics.
+
+5. **Tests:** Add einsum-based tests for `i=>ii` (diagonal), `ij=>iji` (partial diagonal), and a multi-symbol affine case.
+
+### Risk notes
+
+- The `subst` function (line 655) already handles nested `Affine` expansion, so the substitution engine itself needs no changes -- only `make_subst` (which builds the environment) and `check_idcs` (which gates entry) need modification.
+- The guard-insertion path for inconsistent diagonal indices is the most complex part. A conservative first implementation could restrict to cases where call-site indices are consistent (same symbol at both positions), deferring guard insertion to a follow-up.
+- Interaction with gh-ocannl-134 (multiple virtual tensors sharing loops): orthogonal but should be tested together once both land.

--- a/docs/proposals/gh-ocannl-134.md
+++ b/docs/proposals/gh-ocannl-134.md
@@ -1,0 +1,63 @@
+# Allow Multiple Virtual Tensors to Share the Same For Loop
+
+## Goal
+
+Enable multiple virtual (inlined) tensors that are computed within the same for loop to all be virtualized, rather than forcing them to materialize. Currently, when two tensors share a loop iterator symbol, both are marked `is_complex = true` in `visit_llc`, which prevents their virtualization. This limits optimization opportunities in cases like element-wise operations where several intermediate tensors are computed in the same loop.
+
+Tracked by: https://github.com/ahrefs/ocannl/issues/134
+
+## Acceptance Criteria
+
+- Multiple virtual tensors within a single for loop are each inlined correctly at their use sites.
+- `reverse_node_map` is changed from mapping each symbol to a single `Tnode.t` to mapping each symbol to a set of tnodes, so that shared symbols do not force `is_complex = true`.
+- `virtual_llc` handles for loops that contribute computations for multiple virtual tensors: when the loop iterator maps to several tnodes, each virtual tnode's computation is extracted and stored via `check_and_store_virtual`.
+- `cleanup_virtual_llc` removes for loops where all contributing tensors have been virtualized, and preserves loops that still have non-virtual residual operations.
+- `inline_computation` correctly handles inlining a computation that was extracted from a multi-tensor for loop body (the inlined fragment should contain only the operations for the target tnode, not sibling operations).
+- Existing virtual tensor tests continue to pass.
+- No performance regression for programs that do not exercise the multi-virtual-tensor-per-loop pattern.
+
+## Context
+
+### The problem
+
+In `visit_llc` (line ~310-321 of `arrayjit/lib/low_level.ml`), a `track_symbol` helper maps each loop iterator symbol to the tnode it belongs to via `reverse_node_map : (Symbol.t, Tnode.t) Hashtbl.t`. When a second tnode uses the same symbol, both are marked `is_complex <- true`. The comment on line 312 explicitly notes: "See TODO(#134): this prevents multiple virtual arrays from sharing for loops."
+
+The `is_complex` flag blocks virtualization at line 428: `virtualize_settings.inline_simple_computations && (not traced.is_complex)` -- a complex tensor with too many accesses becomes `Never_virtual`.
+
+### Current pipeline
+
+```
+visit_llc -> virtual_llc -> cleanup_virtual_llc -> simplify_llc -> eliminate_common_subexpressions
+```
+
+1. **`visit_llc`** (line 256): traces tensor accesses, builds `reverse_node_map` (symbol -> single tnode), marks `is_complex`.
+2. **`virtual_llc`** (line 775): walks the LLC tree. For `For_loop` nodes whose index maps to a tnode in `reverse_node_map`, it calls `check_and_store_virtual` to record the entire loop as a computation for that single tnode. Currently only one tnode per loop is handled.
+3. **`check_and_store_virtual`** (line 457): validates that a computation block is suitable for inlining (no escaping variables, consistent indices, has setters), then stores it in `computations_table`.
+4. **`inline_computation`** (line 623): at each `Get` site for a virtual tnode, substitutes the stored computation inline, filtering to only the operations on the target tnode (via `Tn.equal` checks on `Set`/`Zero_out`/`Get`).
+5. **`cleanup_virtual_llc`** (line 860): removes operations on now-virtual tnodes from the original locations -- for loops whose iterator maps to a virtual tnode are entirely removed.
+
+### Key insight
+
+`inline_computation` already filters the stored computation body to extract only operations for the target tnode (lines 702-712: `Set`/`Zero_out`/`Get` with `Tn.equal tn traced.tn`). This means even if the full loop body contains operations for multiple tensors, inlining will correctly select only the relevant subset. The main changes needed are in the bookkeeping layer, not the inlining logic itself.
+
+### Approach sketch
+
+1. **Change `reverse_node_map`** from `(Symbol.t, Tnode.t) Hashtbl.t` to `(Symbol.t, Tnode.t list) Hashtbl.t` (or a set). Remove the `is_complex <- true` marking when multiple tnodes share a symbol.
+
+2. **Update `virtual_llc`**: when a for loop's index maps to multiple tnodes, call `check_and_store_virtual` for each virtual tnode in the list, passing the same loop body. Each tnode gets the full loop body stored as its computation.
+
+3. **Update `cleanup_virtual_llc`**: when a for loop's index maps to multiple tnodes, only remove the loop if *all* mapped tnodes are virtual. If some are virtual and some are not, keep the loop but strip out the operations for the virtual tnodes (they have been inlined elsewhere).
+
+4. **Partial loop cleanup**: add logic to `cleanup_virtual_llc` to filter out `Set`/`Zero_out` operations for virtual tnodes within a kept loop body, while preserving operations for non-virtual tnodes.
+
+### Key files
+
+- **`arrayjit/lib/low_level.ml`** -- all functions listed above: `visit_llc` (line 256), `check_and_store_virtual` (line 457), `inline_computation` (line 623), `virtual_llc` (line 775), `cleanup_virtual_llc` (line 860), `optimize_proc` (line 1388)
+- **`arrayjit/lib/tnode.ml`** -- `known_non_virtual`, `update_memory_mode`, `is_complex` usage
+- **`arrayjit/lib/low_level.mli`** -- public interface for `optimize_proc` and related types
+
+### Risks
+
+- **Circular dependencies**: two virtual tensors in the same loop that reference each other. `check_and_store_virtual` already detects escaping variables and recurrence, which should catch most cases. The `process_for` set in `virtual_llc` prevents infinite recursion.
+- **Partial loop stripping correctness**: removing virtual-tnode operations from a mixed loop body while preserving iteration structure requires care. Operations may have ordering dependencies (e.g., a non-virtual tensor reads from a virtual one within the same loop iteration).
+- **`is_complex` serves dual purpose**: it also reflects genuinely complex computations (via `is_complex_comp`), not just symbol sharing. The fix must only remove the symbol-sharing source of complexity, not the computation-complexity source.

--- a/docs/proposals/gh-ocannl-151.md
+++ b/docs/proposals/gh-ocannl-151.md
@@ -1,0 +1,105 @@
+# Proposal: Restore `low_level.Fill` for dedicated backend fill operations
+
+**Issue**: https://github.com/ahrefs/ocannl/issues/151
+
+## Goal
+
+Restore a `Fill` instruction in the low-level IR so that filling an array with a constant value can be mapped to dedicated bulk operations on each backend (`memset` on CC, `cuMemsetD*` on CUDA, `MTLBlitCommandEncoder.fill` on Metal) instead of being expanded into element-by-element loops. This is a performance optimization for the v0.8 milestone.
+
+## Acceptance Criteria
+
+- A `Fill` variant exists in `Low_level.t` that takes a tensor node and a float value.
+- `Fetch { fetch_op = Constant c }` in `assignments.ml` lowers to `Fill` for all constant values (not just 0.0).
+- `Zero_out` becomes a special case of `Fill` (with value 0.0) or is replaced by it.
+- The CC backend (`c_syntax.ml`) emits `memset` for `Fill` with value 0.0, and a typed `memset`-style loop or bulk fill for non-zero values where byte-level memset is not applicable.
+- The CUDA backend emits `cuMemsetD8`/`cuMemsetD16`/`cuMemsetD32` for `Fill` where the value is representable at the appropriate granularity, falling back to a kernel loop otherwise.
+- The Metal backend emits `MTLBlitCommandEncoder.fill` for zero fills, and a compute-based fill for non-zero values.
+- The tracing/optimization pass (`low_level.ml`) handles `Fill` correctly: sets `zero_initialized_by_code` for `Fill 0.0`, tracks assignments, and virtualizes `Fill` nodes identically to `Zero_out`.
+- The `Fill` instruction interacts correctly with padding regions (padding fill happens before the bulk fill, as with `Zero_out` today).
+- All existing tests pass; `.expected` test files are updated to reflect the new IR node.
+- The interpreter (if any) handles `Fill` correctly.
+
+## Context
+
+### History
+
+`Fill` was removed in commit `5e808c79` (2023-05-09) with the message: "Remove `low_level.Fill`, it has tricky semantics -- It was naively and wrongly ignoring `Parallel` / `Task_id`." At that time, the IR had `Parallel` dimension markers and `Task_id` indices for multi-threaded execution. The old `Fill` simply called a whole-array fill, ignoring that in a parallel context each thread should only fill its portion.
+
+Since then, multi-streaming has been removed from OCANNL (gh-ocannl-341), and the `Parallel`/`Task_id` machinery no longer exists in the codebase. The tricky semantics that motivated the removal are no longer relevant.
+
+### Current state
+
+Today, constant filling takes two paths through the IR:
+
+1. **`Fetch { Constant 0.0 }`** lowers to `Zero_out tn` (`assignments.ml:718-719`). In the tracing pass, `Zero_out` sets `zero_initialized_by_code = true` and `zeroed_out = true`. But at **code generation** time in `c_syntax.ml:332-335`, `Zero_out` is expanded into an element-by-element zeroing loop via `loop_over_dims`. No `memset` is used in the generated C/CUDA code.
+
+2. **`Fetch { Constant c }` (non-zero)** lowers directly to `loop_over_dims` + `Set` at the assignments level (`assignments.ml:720-723`), producing an explicit for-loop in the low-level IR. There is no opportunity for the backend to use bulk operations.
+
+3. **`Fetch { Constant neutral_value }`** is also emitted for `initialize_neutral` before accumulating assignments (`assignments.ml:447-450`). The neutral element can be 0.0 (Add/Sub), 1.0 (Mul/Div), infinity (Min), neg_infinity (Max), etc.
+
+Meanwhile, the backends already have bulk fill capabilities that are only used at **allocation** time:
+- CUDA: `Cu.Stream.memset_d8` in `alloc_zeros` (`cuda_backend.ml:84`)
+- Metal: `Me.BlitCommandEncoder.fill_buffer` in `alloc_zeros` (`metal_backend.ml:100`)
+- CC: relies on the OS for zero-initialized allocation
+
+### Key code paths
+
+- **Low-level IR type**: `arrayjit/lib/low_level.ml:33-50` -- `t` variant type, `Zero_out` at line 39
+- **Assignments lowering**: `arrayjit/lib/assignments.ml:718-723` -- `Constant 0.0` to `Zero_out`, other constants to loops
+- **Neutral element init**: `arrayjit/lib/assignments.ml:447-450` -- `Fetch { Constant neutral_value }` before accumulation
+- **C syntax codegen**: `arrayjit/lib/c_syntax.ml:332-335` -- `Zero_out` expanded to loop (not memset)
+- **CUDA alloc_zeros**: `arrayjit/lib/cuda_backend.ml:78-85` -- uses `memset_d8` at allocation only
+- **Metal alloc_zeros**: `arrayjit/lib/metal_backend.ml:92-106` -- uses blit fill at allocation only
+- **Tracing**: `arrayjit/lib/low_level.ml:289-296` -- `Zero_out` tracing sets `zero_initialized_by_code`
+- **Virtualization**: `arrayjit/lib/low_level.ml:794-797`, `883-886` -- `Zero_out` virtualization
+- **CSE/optimization**: `low_level.ml:998,1017,1190,1261,1331,1357` -- `Zero_out` cases in various passes
+- **Neutral elements**: `arrayjit/lib/ops.ml:447` -- `neutral_elem` function (Add->0, Mul->1, Max->neg_inf, etc.)
+
+### Related issues
+
+- **gh-ocannl-420**: Optimize away unnecessary zeroing-out (addresses the `is_surjective` bug causing spurious `Zero_out`). Complementary: #420 reduces the number of fills, #151 makes the remaining fills faster.
+- **gh-ocannl-382**: Remove unnecessary zeroing-out (broader scope).
+- **gh-ocannl-350**: Loop hoisting + CSE (orthogonal optimization).
+
+## Approach
+
+### Step 1: Add `Fill` to the low-level IR
+
+In `low_level.ml` and `low_level.mli`, add a new variant:
+
+```ocaml
+| Fill of { tn : Tnode.t; value : float }
+```
+
+This replaces `Zero_out of Tnode.t`. Keep `Zero_out` as a deprecated alias or remove it outright (replacing all occurrences with `Fill { tn; value = 0.0 }`). Removing `Zero_out` is cleaner since the number of match cases is manageable (~15 locations in `low_level.ml` plus backends).
+
+### Step 2: Update tracing and optimization passes
+
+In every match case that currently handles `Zero_out tn`, handle `Fill { tn; value }` instead:
+- Tracing (`low_level.ml:289`): set `zero_initialized_by_code` when `value = 0.0`, and add a new `fill_initialized` flag or generalize to track the fill value.
+- Virtualization: `Fill` of the virtual node inlines as `Set_local (id, Constant value)`.
+- CSE, structural equality, printing: straightforward replacements.
+
+### Step 3: Update assignments lowering
+
+In `assignments.ml`, change:
+- Line 718-719: `Fetch { Constant 0.0 }` -> `Fill { tn = array; value = 0.0 }` (currently `Zero_out`)
+- Line 720-723: `Fetch { Constant c }` -> `Fill { tn = array; value = c }` (currently `loop_over_dims`)
+
+### Step 4: Backend code generation
+
+**C syntax (`c_syntax.ml`)**: Replace the `Zero_out` handler (lines 332-335) with a `Fill` handler:
+- For `value = 0.0`: emit `memset(tn, 0, size_in_bytes)` instead of an element-by-element loop.
+- For non-zero values: emit a typed fill loop. (A `memset` only works for byte-replicable values. For arbitrary float values, a simple loop is still needed, but the loop is generated at code-gen time rather than polluting the IR.)
+
+**CUDA backend (`cuda_backend.ml`)**: The C syntax module is shared. Additionally, for device-side code, `memset` cannot be called from a kernel. For the CUDA backend, `Fill` should be compiled to a host-side `cuMemsetD*` call injected via `Staged_compilation`, or the loop fallback for non-zero values.
+
+**Metal backend (`metal_backend.ml`)**: Similarly, use `fill_buffer` for zero fills and a compute shader dispatch for non-zero fills.
+
+### Step 5: Allocation optimization
+
+In `backends.ml:485-487`, the allocation path already distinguishes `zero_initialized_by_code` to skip `alloc_zeros`. With `Fill`, generalize: if the node's first operation is `Fill { value = 0.0 }` and we already used `alloc_zeros`, the `Fill` at code-gen time can be skipped (it's redundant). This avoids double-zeroing (the secondary issue from gh-ocannl-420).
+
+### Step 6: Update tests
+
+Update all `.expected` test files to reflect `Fill` instead of `Zero_out` in IR dumps. The `%cd` pretty-printer should show `fill tn value;` instead of `zero_out tn;`.

--- a/docs/proposals/gh-ocannl-164.md
+++ b/docs/proposals/gh-ocannl-164.md
@@ -1,0 +1,154 @@
+# Proposal: Add AVX/AVX2 intrinsics to the C backend
+
+Task: gh-ocannl-164
+Issue: https://github.com/ahrefs/ocannl/issues/164
+
+## Goal
+
+Enable the C backend to leverage AVX/AVX2 SIMD instructions for vectorizable inner loops, with NEON as the ARM/Apple Silicon equivalent. The primary mechanism is compiler auto-vectorization via appropriate flags and code patterns, supplemented by structured loop generation that the compiler can reliably vectorize. This provides a foundation for the explicit SIMD micro-kernels needed by the tiling task (watch-ocannl-README-md-347818d3 / gh-ocannl-412).
+
+## Acceptance Criteria
+
+- The C backend compiles generated code with `-mavx2 -mfma` on x86-64 (in addition to the existing `-march=native`) and verifies that the compiler supports these flags.
+- Memory allocated for tensor buffers is 32-byte aligned (AVX requirement), using `aligned_alloc` or `posix_memalign` instead of the current `Ctypes.allocate_n`.
+- Generated C code uses `__attribute__((aligned(32)))` for stack-allocated local arrays in compiled kernels.
+- The innermost dimension of contiguous-stride loops is emitted with a pattern the compiler can auto-vectorize: simple stride-1 access, no aliasing (use `restrict` on pointer parameters), and loop trip counts visible to the optimizer.
+- A new `builtins_cc.ml` entry provides platform-detection macros (`OCANNL_HAS_AVX2`, `OCANNL_HAS_NEON`) via `#ifdef __AVX2__` / `#ifdef __ARM_NEON` guards.
+- Optional pragma hints (`#pragma GCC ivdep` or `#pragma clang loop vectorize(enable)`) are emitted before inner loops to encourage auto-vectorization.
+- Performance improvement is measurable: at least 2x speedup on a float32 element-wise operation or reduction over arrays of size >= 1024, verified with a benchmark.
+- Graceful fallback: code compiles and runs correctly on architectures without AVX2 (the flags are conditional on platform detection; the generated C code itself uses no explicit intrinsics in this phase).
+- All existing tests pass with no regression.
+
+## Context
+
+### Current compilation pipeline (C backend)
+
+1. **Low-level IR** (`arrayjit/lib/low_level.ml`): `For_loop { index; from_; to_; body; trace_it }` (line 38). `loop_over_dims` (line 1695) generates nested for-loops from dimension arrays. Loops iterate from `from_` to `to_` inclusive.
+
+2. **C code generation** (`arrayjit/lib/c_syntax.ml`): `pp_ll` (line 305) emits C `for` loops. The loop index type is `uint32_t` (or `uint64_t` for big models). Array accesses use computed offsets via `pp_array_offset` (line 275).
+
+3. **CC backend** (`arrayjit/lib/cc_backend.ml`): Compiles generated `.c` files with GCC/Clang. Compiler flags (line 86-96): `-O3 -march=native` by default. The `arch_flags` setting (line 20) defaults to `-march=native` which already enables AVX2 on machines that support it, but the generated code is not structured for auto-vectorization.
+
+4. **Memory allocation** (`arrayjit/lib/backend_impl.ml`): Uses `Ctypes.allocate_n int8_t ~count:size_in_bytes` (line 48), which calls `malloc` -- no alignment guarantee beyond default (typically 16 bytes on 64-bit systems, insufficient for AVX's 32-byte requirement).
+
+5. **Precision types** (`arrayjit/lib/ops.ml`): `Single_prec` -> `float` (4 bytes), `Double_prec` -> `double` (8 bytes). The most common computation precision is `float` (single). AVX2 processes 8 floats or 4 doubles per instruction.
+
+6. **Existing vector support**: `Set_from_vec` IR node (line 41) handles `Uint4x32_to_prec_uniform` conversion -- a fixed-width vector unop. The `c_vec_typ_of_prec` function (ops.ml line 339) defines struct-based vector types (`float4_t`, `double2_t`). These are portable but not SIMD-width.
+
+### Key code locations
+
+| Component | File | Line(s) | Relevance |
+|-----------|------|---------|-----------|
+| `For_loop` codegen | `arrayjit/lib/c_syntax.ml` | 314-331 | Where loop headers are emitted; add pragma hints here |
+| `compile_proc` | `arrayjit/lib/c_syntax.ml` | 756-892 | Function generation; add `restrict` to pointer params |
+| Compiler flags | `arrayjit/lib/cc_backend.ml` | 86-96 | Add conditional AVX2/FMA flags |
+| `arch_flags` setting | `arrayjit/lib/cc_backend.ml` | 20 | Default `-march=native` |
+| Memory allocation | `arrayjit/lib/backend_impl.ml` | 44-51 | Replace with aligned allocation |
+| Local array declarations | `arrayjit/lib/c_syntax.ml` | 860-877 | Add alignment attribute |
+| Includes / builtins | `arrayjit/lib/builtins_cc.ml` | 1-10 | Add platform detection macros |
+| Precision types | `arrayjit/lib/ops.ml` | 324-337 | C type names for SIMD width computation |
+| `C_syntax_config` | `arrayjit/lib/c_syntax.ml` | 16-75 | Module type; may need `restrict` or alignment config |
+
+### Relationship to tiling (gh-ocannl-412 / watch-ocannl-README-md-347818d3)
+
+The tiling proposal explicitly depends on SIMD support for its micro-kernel. It calls for explicit AVX2 `_mm256_fmadd_ps` / NEON `vfmaq_f32` intrinsics in the tiled inner loop. This task provides the **foundation**: aligned memory, correct compiler flags, auto-vectorization-friendly loop patterns, and platform detection macros. The tiling task will then add explicit intrinsic emission for the micro-kernel. This separation keeps the two tasks independent and testable.
+
+## Approach
+
+### Phase 1: Aligned memory allocation
+
+**File: `arrayjit/lib/backend_impl.ml`**
+
+Replace `Ctypes.allocate_n int8_t ~count:size_in_bytes` with aligned allocation:
+
+```ocaml
+let aligned_alloc ~alignment ~size_in_bytes =
+  let ptr = Ctypes.(to_voidp @@ coerce (ptr void) (ptr int8_t)
+    (Foreign.foreign "aligned_alloc" Ctypes.(size_t @-> size_t @-> returning (ptr void))
+       (Unsigned.Size_t.of_int alignment) (Unsigned.Size_t.of_int size_in_bytes))) in
+  ...
+```
+
+Use 32-byte alignment (sufficient for AVX/AVX2; AVX-512 would need 64). Fall back to `posix_memalign` on platforms where `aligned_alloc` is unavailable. The size must be rounded up to a multiple of the alignment.
+
+Note: `aligned_alloc` requires the size to be a multiple of alignment. Add a rounding helper.
+
+### Phase 2: Compiler flags and platform detection
+
+**File: `arrayjit/lib/cc_backend.ml`**
+
+The existing `arch_flags` default of `-march=native` already enables AVX2 on capable hardware. Add explicit flag validation: attempt compilation with `-mavx2 -mfma` and cache whether the compiler/platform supports them. If supported, also pass `-ftree-vectorize` (usually on by default at `-O3`, but making it explicit helps).
+
+**File: `arrayjit/lib/builtins_cc.ml`**
+
+Add platform detection macros to the `includes` string:
+
+```c
+#ifdef __AVX2__
+  #define OCANNL_HAS_AVX2 1
+  #include <immintrin.h>
+#else
+  #define OCANNL_HAS_AVX2 0
+#endif
+
+#ifdef __ARM_NEON
+  #define OCANNL_HAS_NEON 1
+  #include <arm_neon.h>
+#else
+  #define OCANNL_HAS_NEON 0
+#endif
+```
+
+These macros are needed by the tiling task for explicit intrinsics, and immediately useful for any conditional SIMD code paths.
+
+### Phase 3: Auto-vectorization-friendly code generation
+
+**File: `arrayjit/lib/c_syntax.ml`**
+
+3a. **`restrict` qualifiers on pointer parameters** (in `compile_proc`, around line 773):
+
+Change parameter declarations from `float *arr` to `float * restrict arr`. This tells the compiler that pointers don't alias, which is a prerequisite for auto-vectorization. OCANNL's memory model supports this: each tensor has its own allocation.
+
+3b. **Vectorization pragma hints** (in `pp_ll`, around line 314):
+
+Before the innermost `for` loop (detected by checking whether the loop body contains no nested `For_loop`), emit:
+
+```c
+#if defined(__GNUC__)
+#pragma GCC ivdep
+#elif defined(__clang__)
+#pragma clang loop vectorize(enable) interleave(enable)
+#endif
+```
+
+Detection of "innermost loop" requires a simple check: scan the body for `For_loop` nodes. If none found, this is an inner loop candidate for the pragma.
+
+3c. **Alignment attribute on local arrays** (in `compile_proc`, around line 868-874):
+
+Change local array declarations from:
+```c
+float arr[N];
+```
+to:
+```c
+float arr[N] __attribute__((aligned(32)));
+```
+
+This ensures stack-allocated arrays used in inner loops are aligned for SIMD access.
+
+### Phase 4: Verification and benchmarking
+
+Add a benchmark (in `test/` or `bin/`) that:
+1. Creates a float32 array of size 4096+
+2. Runs an element-wise operation (e.g., `c[i] = a[i] + b[i]`) and a reduction (e.g., dot product)
+3. Measures throughput with and without the vectorization-friendly changes
+4. Verifies numerical correctness
+
+The benchmark can use the existing `Utils.get_global_flag` mechanism to toggle the new features, comparing performance.
+
+### What this task does NOT do
+
+- **No explicit SIMD intrinsics** (`_mm256_fmadd_ps`, etc.) in generated code -- that belongs to the tiling task (watch-ocannl-README-md-347818d3).
+- **No loop tiling or reordering** -- that is gh-ocannl-412.
+- **No multi-threading** -- out of scope.
+- **No AVX-512** -- AVX2 is the baseline; AVX-512 can be added later behind a feature flag.

--- a/docs/proposals/gh-ocannl-170.md
+++ b/docs/proposals/gh-ocannl-170.md
@@ -1,0 +1,199 @@
+# Proposal: Use `cuMemAllocHost` for pinned staging buffers in CUDA backend
+
+Task: gh-ocannl-170
+Issue: https://github.com/ahrefs/ocannl/issues/170
+
+## Goal
+
+Speed up CPU-GPU memory transfers in the CUDA backend by using pinned (page-locked) host memory for staging buffers. Pinned memory enables DMA transfers and can be 2-3x faster for host-device copies. Following the CUDA documentation's warning, pinned memory is used sparingly -- only for reusable staging buffers, not for all bigarrays.
+
+## Acceptance Criteria
+
+- A per-stream pinned staging buffer is allocated via `cuMemAllocHost` in the CUDA backend, used as an intermediary for `from_host` and `to_host` transfers.
+- The staging buffer is grown lazily (allocated on first use, reallocated when a larger transfer is needed) and freed when the stream is finalized.
+- Regular host-side bigarrays (created by `Ndarray.create_array`) remain unpinned -- no changes to `Ndarray` module.
+- `cuMemAllocHost` and `cuMemFreeHost` bindings are added to `ocaml-cudajit` (in `cuda_ffi/bindings.ml`, `src/cuda.ml`, `src/cuda.mli`).
+- Transfers via the staging buffer are correct: data round-trips through `from_host` -> kernel -> `to_host` produce identical results to the current implementation.
+- All existing CUDA tests pass with no regression.
+- The feature can be disabled via an environment variable or global setting for debugging purposes (e.g., `OCANNL_NO_PINNED_STAGING=1`).
+
+## Context
+
+### Current transfer path
+
+Host-device transfers in the CUDA backend go through `Cu.Stream.memcpy_H_to_D` and `Cu.Stream.memcpy_D_to_H`, which are async wrappers around `cuMemcpyHtoDAsync` and `cuMemcpyDtoHAsync`. These operate on regular (pageable) host memory from OCaml bigarrays created via `Bigarray.Genarray.create`.
+
+When source host memory is pageable, the CUDA driver must internally copy it to a pinned staging buffer before DMA transfer. This double-copy is the performance bottleneck this task eliminates.
+
+### Key code locations
+
+| Component | File | Line(s) | Relevance |
+|-----------|------|---------|-----------|
+| `from_host` | `arrayjit/lib/cuda_backend.ml` | 258-261 | H2D transfer: calls `Cu.Stream.memcpy_H_to_D` with bigarray |
+| `to_host` | `arrayjit/lib/cuda_backend.ml` | 263-266 | D2H transfer: calls `Cu.Stream.memcpy_D_to_H` with bigarray |
+| `alloc_if_needed` | `arrayjit/lib/backends.ml` | 470-559 | Initial H2D for constants; calls `Device.from_host` |
+| `Ndarray.create_array` | `arrayjit/lib/ndarray.ml` | 470-482 | Host array creation via `Bigarray.Genarray.create` (unchanged) |
+| Device buffer alloc | `arrayjit/lib/cuda_backend.ml` | 58-88 | `Alloc_buffer` module: `mem_alloc`, `alloc_zeros`, `free_buffer` |
+| Stream finalization | `arrayjit/lib/cuda_backend.ml` | 130-135 | `finalize_device`: frees cross-stream buffers |
+| Merge buffer pattern | `arrayjit/lib/cuda_backend.ml` | 121-128 | `opt_alloc_merge_buffer`: lazy grow pattern (model for staging buffer) |
+| cudajit `Deviceptr` | `ocaml-cudajit/src/cuda.ml` | ~1489 | `mem_alloc` / `mem_free`: pattern for new `mem_alloc_host` / `mem_free_host` |
+| cudajit FFI bindings | `ocaml-cudajit/cuda_ffi/bindings.ml` | 43-48 | `cu_mem_alloc` / `cu_mem_alloc_async`: pattern for new binding |
+
+### Dependency: ocaml-cudajit bindings
+
+`cuMemAllocHost` and `cuMemFreeHost` are **not yet bound** in ocaml-cudajit. The gh-ocaml-cudajit-5 task (broader pinned memory API: `Hostptr` module, `cuMemHostAlloc`, `cuMemHostRegister`, etc.) was planned but its code has not landed in the ocaml-cudajit main branch. This task requires a minimal subset: just `cuMemAllocHost` and `cuMemFreeHost`.
+
+### Merge buffer as design precedent
+
+The existing `opt_alloc_merge_buffer` in `cuda_backend.ml` (line 121-128) demonstrates the lazy-grow pattern for per-stream device-side buffers. The pinned staging buffer follows the same pattern on the host side: allocate on first use, grow when needed, free on finalization.
+
+## Approach
+
+### Step 1: Add minimal `cuMemAllocHost`/`cuMemFreeHost` bindings to ocaml-cudajit
+
+**File: `ocaml-cudajit/cuda_ffi/bindings.ml`**
+
+Add two new FFI bindings after the existing `cu_mem_free_async` (line 112):
+
+```ocaml
+let cu_mem_alloc_host =
+  F.foreign "cuMemAllocHost" F.(ptr (ptr void) @-> size_t @-> returning E.cu_result)
+
+let cu_mem_free_host =
+  F.foreign "cuMemFreeHost" F.(ptr void @-> returning E.cu_result)
+```
+
+**File: `ocaml-cudajit/src/cuda.ml`** (in the `Deviceptr` section or as standalone functions)
+
+Add two host-pinned memory functions. Since this is a minimal approach (not the full `Hostptr` module from gh-ocaml-cudajit-5), expose them as top-level or `Deviceptr`-adjacent functions:
+
+```ocaml
+let mem_alloc_host ~size_in_bytes =
+  let pp = allocate (ptr void) null in
+  check "cu_mem_alloc_host"
+  @@ Cuda.cu_mem_alloc_host pp (Unsigned.Size_t.of_int size_in_bytes);
+  !@pp
+
+let mem_free_host ptr =
+  check "cu_mem_free_host" @@ Cuda.cu_mem_free_host ptr
+```
+
+These return/accept `unit Ctypes.ptr` (void pointer), which can be used directly with the existing `memcpy_H_to_D_unsafe` and `memcpy_D_to_H_unsafe` functions that already accept `unit Ctypes.ptr`.
+
+**File: `ocaml-cudajit/src/cuda.mli`**
+
+Expose the two new functions with appropriate documentation:
+
+```ocaml
+val mem_alloc_host : size_in_bytes:int -> unit Ctypes.ptr
+(** Allocates page-locked (pinned) host memory. See cuMemAllocHost. *)
+
+val mem_free_host : unit Ctypes.ptr -> unit
+(** Frees pinned host memory allocated by [mem_alloc_host]. See cuMemFreeHost. *)
+```
+
+### Step 2: Add per-stream pinned staging buffer to CUDA backend
+
+**File: `arrayjit/lib/cuda_backend.ml`**
+
+Add a `staging_buffer` field to the stream state, following the `merge_buffer` pattern:
+
+```ocaml
+type pinned_staging = {
+  host_ptr : unit Ctypes.ptr;
+  size_in_bytes : int;
+}
+```
+
+Add a per-stream `staging_buffer : pinned_staging option ref` field (in the stream record or as part of `Device_stream`). Lazily allocate/grow it:
+
+```ocaml
+let opt_alloc_staging_buffer ~size_in_bytes stream =
+  if Option.value_map ~default:true !(stream.staging_buffer) ~f:(fun buf ->
+      buf.size_in_bytes < size_in_bytes)
+  then (
+    Option.iter !(stream.staging_buffer) ~f:(fun buf -> Cu.mem_free_host buf.host_ptr);
+    let host_ptr = Cu.mem_alloc_host ~size_in_bytes in
+    stream.staging_buffer := Some { host_ptr; size_in_bytes })
+```
+
+### Step 3: Route transfers through the staging buffer
+
+**File: `arrayjit/lib/cuda_backend.ml`**
+
+Modify `from_host` and `to_host` to use the pinned staging buffer when available:
+
+```ocaml
+let from_host ~dst_ptr ~dst hosted =
+  set_ctx @@ ctx_of dst;
+  if use_pinned_staging () then begin
+    let size = Ndarray.size_in_bytes hosted in
+    opt_alloc_staging_buffer ~size_in_bytes:size dst.stream;
+    let staging = Option.value_exn !(dst.stream.staging_buffer) in
+    (* Copy pageable bigarray -> pinned staging (CPU memcpy) *)
+    Ndarray.unsafe_blit_to_ptr hosted staging.host_ptr;
+    (* Copy pinned staging -> device (DMA, async) *)
+    Cu.Stream.memcpy_H_to_D_unsafe ~dst:dst_ptr ~src:staging.host_ptr
+      ~size_in_bytes:size dst.stream.runner
+  end else begin
+    let f src = Cu.Stream.memcpy_H_to_D ~dst:dst_ptr ~src dst.stream.runner in
+    Ndarray.apply { f } hosted
+  end
+```
+
+The `to_host` function follows the reverse pattern: device -> pinned staging (DMA), then pinned staging -> pageable bigarray (CPU memcpy).
+
+Note: `Ndarray.unsafe_blit_to_ptr` and `Ndarray.unsafe_blit_from_ptr` are new utility functions that perform a CPU `memcpy` between a bigarray and a `unit Ctypes.ptr`. These are thin wrappers around `Ctypes.memcpy` or `Bigarray` pointer arithmetic.
+
+### Step 4: Clean up on finalization
+
+**File: `arrayjit/lib/cuda_backend.ml`**
+
+In the stream or device finalization path, free the staging buffer:
+
+```ocaml
+(* In finalize_device or stream cleanup *)
+Option.iter !(stream.staging_buffer) ~f:(fun buf -> Cu.mem_free_host buf.host_ptr)
+```
+
+### Step 5: Opt-out mechanism
+
+Add a check in `Utils.settings` or via environment variable:
+
+```ocaml
+let use_pinned_staging () =
+  not (Utils.get_global_flag ~default:false ~arg_name:"no_pinned_staging")
+```
+
+This allows disabling pinned staging for debugging or on systems with limited pinned memory budget.
+
+### Step 6: Add Ndarray utility functions
+
+**File: `arrayjit/lib/ndarray.ml`**
+
+Add functions to copy between bigarrays and raw pointers:
+
+```ocaml
+let size_in_bytes nd =
+  apply { f = fun arr -> Bigarray.Genarray.size_in_bytes arr } nd
+
+let unsafe_blit_to_ptr nd dst_ptr =
+  let f arr =
+    let src = Ctypes_bigarray.unsafe_address arr in
+    let size = Bigarray.Genarray.size_in_bytes arr in
+    Ctypes.(memcpy (to_voidp (from_voidp char dst_ptr))
+                   (to_voidp (from_voidp char (ptr_of_raw_address src)))
+                   size)
+  in
+  apply { f } nd
+
+let unsafe_blit_from_ptr nd src_ptr =
+  (* Reverse direction *)
+  ...
+```
+
+### Testing
+
+No new test files needed. The existing CUDA backend tests exercise `from_host` and `to_host` paths. When pinned staging is enabled (the default), all existing tests validate correctness. The opt-out flag can be used to compare performance.
+
+A manual benchmark comparing transfer times with and without pinned staging (using `OCANNL_NO_PINNED_STAGING=1`) would confirm the speedup, but is not required for correctness acceptance.

--- a/docs/proposals/gh-ocannl-195.md
+++ b/docs/proposals/gh-ocannl-195.md
@@ -1,0 +1,107 @@
+# Proposal: Re-introduce CUDA `__constant__` Memory for Qualifying Tensors
+
+**Task**: gh-ocannl-195
+**Issue**: https://github.com/ahrefs/ocannl/issues/195
+
+## Goal
+
+Selectively place small, read-only (`Effectively_constant` / `Hosted Constant`) tensors into CUDA `__constant__` memory to exploit the hardware constant cache. This is a targeted optimization for data that all threads in a warp read from the same address simultaneously (broadcast access pattern), which becomes relevant once multi-threaded kernels (gh-ocannl-412) are implemented.
+
+## Acceptance Criteria
+
+- [ ] Tensors marked `Effectively_constant` or `Hosted Constant` that are (a) small enough to fit within a per-kernel constant memory budget (configurable, default 16KB out of 64KB total) and (b) not mutated between kernel launches are emitted as `__constant__` device variables instead of kernel pointer parameters
+- [ ] The CUDA code generator in `c_syntax.ml` / `cuda_backend.ml` emits `__constant__ <type> <name>[<size>];` declarations for qualifying tensors, and references them directly in kernel bodies (no pointer parameter needed)
+- [ ] At link time, `Cu.Module.get_global` (already bound in ocaml-cudajit) is used to obtain the device pointer to each `__constant__` variable, and `Cu.Stream.memcpy_H_to_D` copies the host data into it once
+- [ ] A cumulative constant memory tracker prevents exceeding 64KB per CUDA module; tensors that would overflow the budget fall back to regular global memory (kernel pointer parameter)
+- [ ] The constant memory budget is configurable via `Utils.settings` or a global arg (`cuda_constant_memory_budget`, default 16384 bytes)
+- [ ] All existing CUDA tests pass with no regression
+- [ ] A benchmark comparing constant memory vs global memory for a workload with small constant tensors (e.g., number literals, small lookup tables, positional encoding tables) shows the expected cache benefit under multi-threaded execution (or documents that single-threaded mode shows no measurable difference, confirming the optimization is forward-looking)
+
+## Context
+
+### CUDA Constant Memory Characteristics
+
+CUDA constant memory is a 64KB region of read-only device memory with a dedicated cache. Key properties:
+
+- **Broadcast**: When all threads in a warp read the same address, the constant cache serves the request in a single cycle -- as fast as reading a register
+- **Serialization**: When different threads read different addresses, accesses are serialized -- potentially 32x slower than global memory with L1/L2 cache
+- **Per-module**: Each `CUmodule` has its own 64KB constant memory space. Variables are declared with `__constant__` in CUDA source and populated via `cuModuleGetGlobal` + `cuMemcpyHtoD` after module load
+- **Static lifetime**: Constant memory persists for the lifetime of the module; it cannot be dynamically resized
+
+### Current Architecture
+
+**Tensors are passed as kernel pointer parameters.** In `c_syntax.ml` `compile_proc` (line 756), every materialized or in-context tensor becomes a pointer parameter to the kernel function. The `link_proc` function in `cuda_backend.ml` (line 929) maps each `Param_ptr tn` to a `Cu.Stream.Tensor` kernel argument.
+
+**`Effectively_constant` is already tracked.** The `Tnode.memory_mode` type (in `tnode.ml` line 48) includes `Effectively_constant`, set for number literals, fixed parameters, and constant-filled tensors (`tensor.ml` lines 585, 601, 639). The `known_constant` function (`tnode.ml` line 273) returns true for these. Backends currently do not special-case this -- they are allocated as regular device memory.
+
+**`__constant__` is already used for builtins.** The ThreeFry PRNG in `builtins_cuda.ml` (line 297) uses `__device__ __constant__ unsigned int THREEFRY_C240 = ...` and `THREEFRY_ROTATION[8][4]`. These are hardcoded strings embedded in the CUDA source. This confirms the compilation pipeline (NVRTC + module loading) handles `__constant__` declarations correctly.
+
+**`cuModuleGetGlobal` is bound.** The ocaml-cudajit binding (`cuda.ml` line 1792) wraps `cuModuleGetGlobal_v2`, returning a `Deviceptr.t` and size. This is the API needed to locate `__constant__` variables after module loading.
+
+**Kernels run single-threaded today.** The `kernel_prep_line` guard (`cuda_backend.ml` line 329) forces `grid_dim=1, block_dim=1`. Constant memory's broadcast advantage requires multiple threads reading the same address in a warp. Until gh-ocannl-412 (multi-threaded kernels), the performance benefit is negligible.
+
+### Relevant Code Locations
+
+| Component | File | Lines | Relevance |
+|-----------|------|-------|-----------|
+| Memory mode type | `arrayjit/lib/tnode.ml` | 47-55 | `Effectively_constant` definition |
+| `known_constant` | `arrayjit/lib/tnode.ml` | 273-276 | Predicate for constant tensors |
+| Kernel param assembly | `arrayjit/lib/c_syntax.ml` | 756-810 | Where tensor params are collected; needs branching for constant tensors |
+| Kernel launch | `arrayjit/lib/cuda_backend.ml` | 929-987 | `link_proc`: maps params to kernel args; constant tensors bypass this |
+| Module loading | `arrayjit/lib/cuda_backend.ml` | 989-1002 | `link`: loads PTX module; constant data copy goes here |
+| Existing `__constant__` | `arrayjit/lib/builtins_cuda.ml` | 297-309 | ThreeFry constants pattern |
+| `cuModuleGetGlobal` | `ocaml-cudajit/src/cuda.ml` | 1789-1794 | OCaml binding already available |
+| Tensor constant marking | `tensor/tensor.ml` | 585, 601, 639 | Where `Effectively_constant` is set |
+
+### Why Not Wait for Multi-Threaded Kernels?
+
+The implementation is low-risk and can be done incrementally:
+
+1. **The plumbing is straightforward**: The code generator needs to emit `__constant__` declarations instead of params, and the linker needs one `Cu.Module.get_global` + memcpy per constant tensor. These are small, self-contained changes.
+2. **It reduces kernel parameter count**: Even in single-threaded mode, moving constants out of the kernel parameter list simplifies the launch interface. CUDA has a 4KB limit on kernel parameters; for models with many small constant tensors, this overhead matters.
+3. **It's testable now**: Correctness can be verified immediately. Performance testing waits for gh-ocannl-412.
+4. **Forward compatibility**: When multi-threaded kernels land, constant memory is automatically exploited without further changes.
+
+However, if the team prefers to focus v0.8 effort on gh-ocannl-412 first, this task can be deferred to a post-412 follow-up with no architectural cost.
+
+## Approach
+
+### Phase 1: Code Generation for `__constant__` Declarations
+
+**Modify `c_syntax.ml` `compile_proc`** to partition tensors into constant-memory vs regular params:
+
+1. After the current `Hashtbl.fold traced_store` that builds the `params` list, add a separate pass that identifies qualifying constant tensors: `Tn.known_constant tn && not (Tn.known_virtual tn) && size_in_bytes <= budget`.
+2. For qualifying tensors, emit a `__constant__ <type> <name>[<num_elements>];` declaration before the kernel function (as a module-level declaration, similar to builtins).
+3. Remove these tensors from the `params` list so they are not kernel arguments.
+4. Kernel body references to these tensors remain unchanged (array indexing works the same whether the array is a parameter pointer or a module-level `__constant__` variable).
+
+This requires a new hook in `C_syntax_config`: `constant_declarations : (Tn.t * string) list -> PPrint.document` that is non-empty only for the CUDA backend.
+
+**Track cumulative usage**: A mutable counter accumulates the size of all `__constant__` tensors per compilation unit. When the budget is exhausted, remaining qualifying tensors fall back to regular params.
+
+### Phase 2: Data Population at Link Time
+
+**Modify `cuda_backend.ml` `link` and `link_batch`** to populate constant memory after module loading:
+
+1. After `Cu.Module.load_data_ex`, iterate over the constant tensors recorded during code generation.
+2. For each, call `Cu.Module.get_global run_module ~name:<ident>` to get the device pointer.
+3. Copy the host data with `Cu.Stream.memcpy_H_to_D` (or synchronous `Cu.Deviceptr.memcpy_H_to_D` since constant memory must be set before any kernel launch using it).
+
+The `code` record in `cuda_backend.ml` (line 295) needs a new field: `constant_tensors : Tn.t list` listing the tensors placed in constant memory (so `link_proc` knows which tensors are NOT in the params list).
+
+### Phase 3: Configuration and Safety
+
+- Add `cuda_constant_memory_budget` to `Utils.settings` or as a global arg (default 16384).
+- Add a diagnostic log (at log level 3+) listing which tensors were placed in constant memory and the total constant memory usage.
+- Ensure `Effectively_constant` tensors that might change between training steps (like learning rate schedules) are excluded. The `known_constant` predicate in `tnode.ml` already distinguishes `Hosted Constant` from `Hosted Volatile`; only the former qualifies.
+
+### Phase 4: Testing and Benchmarking
+
+- Run existing CUDA test suite to verify no regression.
+- Add a targeted test: create a model with several small constant tensors (scalar multipliers, bias terms), verify that the generated CUDA source contains `__constant__` declarations and that the kernel parameter list is shorter.
+- Benchmark under single-threaded mode to confirm no regression (expected: neutral performance, possibly slight improvement from reduced param parsing).
+- Document that significant performance gains are expected only after gh-ocannl-412 enables multi-threaded execution with warp-level broadcast patterns.
+
+### Estimated Effort
+
+Small-medium (2-3 days). The core changes are in `c_syntax.ml` and `cuda_backend.ml`, with no changes needed to the IR, tensor system, or ocaml-cudajit bindings.

--- a/docs/proposals/gh-ocannl-253.md
+++ b/docs/proposals/gh-ocannl-253.md
@@ -1,0 +1,170 @@
+# Proposal: Study and Incorporate llm.c Lessons
+
+**Task**: gh-ocannl-253
+**Issue**: https://github.com/ahrefs/ocannl/issues/253
+**Milestone**: v0.8
+
+## Goal
+
+Produce a structured analysis of Andrej Karpathy's [llm.c](https://github.com/karpathy/llm.c) project, identifying which design decisions and optimization techniques are applicable to OCANNL, which are already covered by existing tasks, and which represent unique lessons that should inform OCANNL's v0.8-v0.9 development. The deliverable is a documented gap analysis with concrete recommendations, not direct code porting -- llm.c is hand-written C/CUDA for GPT-2, while OCANNL generates kernels from a high-level einsum IR. The value is in understanding *why* llm.c's choices work and mapping those insights to OCANNL's architecture.
+
+## Acceptance Criteria
+
+- [ ] A written analysis document (`docs/llm-c-analysis.md`) covering all major llm.c subsystems listed in the Context section below, with each subsystem assessed for OCANNL applicability
+- [ ] Each llm.c technique is classified as: (a) already addressed by an existing OCANNL task, (b) applicable and recommended for a specific OCANNL milestone, or (c) not applicable with rationale
+- [ ] For techniques in category (b), the analysis includes concrete recommendations: which OCANNL file/module would change, what the change looks like at a high level, and which milestone it fits
+- [ ] Identification of any llm.c patterns that challenge OCANNL's architectural assumptions (e.g., patterns that are hard to express in the einsum IR or that require manual kernel specialization)
+- [ ] The analysis references specific llm.c source files and line ranges for traceability
+- [ ] Cross-references to existing OCANNL proposals (gh-ocannl-412 tiling, gh-ocannl-164 AVX/AVX2, gh-ocannl-318 megakernels) are explicit, noting what each existing task covers and what gaps remain
+- [ ] A summary table mapping llm.c components to OCANNL equivalents/gaps
+
+## Context
+
+### What llm.c Is
+
+llm.c implements GPT-2 (124M) training in pure C and CUDA, achieving parity with PyTorch fp32 training performance. Key characteristics:
+- Single-file C implementation (`train_gpt2.c`) and single-file CUDA implementation (`train_gpt2.cu` / `train_gpt2_fp32.cu`)
+- All operations hand-written: matmul, layernorm, softmax, GELU, attention, residual connections, AdamW optimizer
+- Multi-GPU training via NCCL
+- Mixed precision (fp32 and bf16/fp16 paths)
+- Achieves PyTorch-level throughput through careful memory management, kernel fusion, and GPU utilization
+
+### llm.c Subsystems to Analyze
+
+**1. Kernel implementations (CUDA)**
+- Matrix multiplication: custom tiled CUDA kernels, cuBLAS integration, cooperative groups
+- LayerNorm: fused mean+variance computation, online Welford algorithm, vectorized loads (`float4`)
+- Softmax: online softmax algorithm (numerically stable single-pass), warp-level reductions
+- GELU: fused activation with `tanhf` approximation
+- Attention: fused attention score computation, causal masking, softmax, attention output
+- Residual connections: fused add operations
+- Cross-entropy loss: fused softmax + log-likelihood in single kernel
+
+**Already covered by existing tasks:**
+- Matrix multiplication tiling/parallelization -> gh-ocannl-412 (comprehensive 5-phase proposal covering IR tiling, multi-threaded CUDA, SMEM, register blocktiling, C backend tiling)
+- AVX/AVX2 for CPU inner loops -> gh-ocannl-164 (aligned memory, compiler flags, auto-vectorization)
+- Megakernel approach -> gh-ocannl-318 (deep dive document already exists at `docs/megakernel-deep-dive.md`)
+
+**NOT covered by existing tasks (unique llm.c lessons):**
+- Fused reduction kernels (layernorm, softmax) with warp shuffle primitives (`__shfl_xor_sync`, `__shfl_down_sync`)
+- Online/streaming algorithms for numerically stable reductions (Welford for variance, online softmax)
+- Vectorized memory access patterns (`float4` loads/stores for coalesced memory access)
+- Fused activation functions (GELU as a single inlined computation)
+- Cooperative groups for flexible thread synchronization
+
+**2. Memory management**
+- Pre-allocated contiguous parameter and gradient buffers (single `malloc` for all weights)
+- Activation checkpointing / recomputation during backprop
+- In-place operations where possible (residual adds)
+- Memory-mapped weight loading from checkpoint files
+
+**OCANNL relevance:**
+- OCANNL allocates per-tensor buffers (via `Cu.Deviceptr.mem_alloc` per tensor in `cuda_backend.ml`). llm.c's contiguous allocation reduces allocation overhead and enables pointer arithmetic. The pool allocator planned for v0.7.2 (gh-ocannl-344) partially addresses this.
+- Activation checkpointing is not currently in OCANNL's scope but becomes important for training larger models. The `Virtual` memory mode and virtualization pass in OCANNL serve a related purpose (eliminating intermediate allocations) but don't support recomputation.
+
+**3. Training loop design**
+- Gradient accumulation across micro-batches
+- Learning rate warmup + cosine decay schedule
+- Gradient clipping (global norm)
+- Validation loss computation interleaved with training
+- Checkpoint saving/restoring
+
+**OCANNL relevance:**
+- OCANNL's `Train` module provides `sgd_one` (SGD with momentum) but no AdamW, learning rate scheduling, or gradient clipping. These are higher-level training utilities.
+- The `sequential_loop` and `round_robin` functions in `train.ml` handle batch iteration but not gradient accumulation across micro-batches.
+- llm.c's training loop patterns are informative for OCANNL's training examples (v0.7.1 milestone: MNIST, CIFAR, transformer inference).
+
+**4. CUDA optimization patterns**
+- Warp-level primitives: `__shfl_xor_sync`, `__shfl_down_sync` for intra-warp reductions without shared memory
+- Block-level reductions: two-phase reduction (intra-warp shuffle, then inter-warp via shared memory)
+- Memory coalescing: careful index arithmetic to ensure adjacent threads access adjacent memory
+- Occupancy tuning: block sizes chosen to maximize SM occupancy
+- Stream-based overlapping of compute and data transfer
+
+**OCANNL relevance:**
+- Warp shuffles are absent from OCANNL's CUDA builtins (`builtins_cuda.ml`). Adding them would benefit any reduction operation (layernorm, softmax, loss computation) on GPU. This is a gap not covered by gh-ocannl-412 (which focuses on matmul tiling).
+- Memory coalescing is implicitly addressed by the tiling proposal (gh-ocannl-412 Phase 2) but only for matmul. General coalesced access patterns for element-wise and reduction operations need attention.
+- OCANNL currently launches one kernel per routine; there is no compute/transfer overlap.
+
+**5. Numerical precision**
+- Mixed precision training: bf16 forward/backward, fp32 master weights and optimizer state
+- Stochastic rounding for gradient updates
+- Kahan summation for accurate gradient accumulation
+
+**OCANNL relevance:**
+- OCANNL has `Half_prec`, `Bfloat16_prec`, and `Fp8_prec` type support in `ops.ml` and corresponding CUDA types in `cuda_backend.ml`. However, there is no mixed-precision training infrastructure (maintaining fp32 master weights alongside bf16 compute weights).
+- This is a v0.9+ concern but worth documenting as a gap.
+
+### OCANNL Architecture Constraints
+
+Key constraints that affect which llm.c lessons transfer cleanly:
+
+1. **Generated kernels, not hand-written.** OCANNL generates C/CUDA from the `Low_level.t` IR. Any llm.c technique must be expressible as an IR transformation or code generation pattern, not as a hand-written kernel.
+
+2. **Einsum-based computation model.** Operations are specified as einsum contractions with batch/output/input dimensions. llm.c's operation-specific kernels (e.g., "fused layernorm kernel") would need to be recognized as patterns in the einsum IR and lowered to specialized code.
+
+3. **Single-threaded kernels (current state).** All CUDA kernels run with `grid_dim=1, block_dim=1`. The tiling proposal (gh-ocannl-412) is the prerequisite for any llm.c GPU optimization technique.
+
+4. **No GELU activation.** OCANNL's `nn_blocks.ml` provides `relu`, `softmax`, `layer_norm`, `dropout`, and attention blocks, but no GELU. Adding GELU is straightforward (it composes from existing operations: `x * 0.5 * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))`) but does not currently exist.
+
+5. **SGD only.** The `Train` module has SGD with momentum/weight_decay/Nesterov, but no Adam/AdamW optimizer. AdamW is essential for transformer training.
+
+### Related Proposals and Documents
+
+| Document | Coverage |
+|----------|----------|
+| `docs/proposals/gh-ocannl-412.md` | Tiling, multi-threaded CUDA, SMEM, register blocktiling (5 phases) |
+| `docs/proposals/gh-ocannl-164.md` | AVX/AVX2 intrinsics, aligned memory, auto-vectorization for C backend |
+| `docs/megakernel-deep-dive.md` | Megakernel patterns from Hazy Research and Mirage MPK, mapped to OCANNL |
+| `docs/proposals/gh-ocannl-377.md` | Transformer inference demo (GPT-2/LLaMA) |
+| `ROADMAP.md` | v0.8 = GPU-style performance (tiling + megakernels + llm.c lessons) |
+
+## Approach
+
+### Phase 1: llm.c Source Study (1-2 days)
+
+Read and annotate the following llm.c source files:
+- `train_gpt2.c`: CPU reference implementation -- understand the complete training pipeline
+- `train_gpt2_fp32.cu` (or `train_gpt2.cu`): CUDA implementation -- focus on kernel implementations
+- `llmc/` directory: modular CUDA kernels (matmul, layernorm, attention, etc.)
+
+For each kernel/subsystem, document:
+- The algorithm and its performance characteristics
+- Which CUDA primitives it uses (warp shuffles, shared memory, cooperative groups, etc.)
+- Memory access patterns and how coalescing is achieved
+- Whether the technique is general or GPT-2-specific
+
+### Phase 2: Gap Analysis (1 day)
+
+Cross-reference llm.c techniques against:
+1. Existing OCANNL capabilities (what already works)
+2. Existing proposals (gh-ocannl-412, gh-ocannl-164, gh-ocannl-318)
+3. OCANNL's IR constraints (what can be expressed as IR transformations)
+
+Produce a classification table for every identified technique.
+
+### Phase 3: Recommendations Document (1 day)
+
+Write `docs/llm-c-analysis.md` with:
+- Executive summary of findings
+- Per-subsystem analysis sections
+- Recommendations table: technique, OCANNL applicability, target milestone, effort estimate
+- Architectural insights: patterns that are hard for OCANNL's IR to express, with suggestions for IR extensions
+
+### Prioritized Recommendations (Expected)
+
+Based on preliminary analysis, the likely priority ordering for unique llm.c lessons (not already covered by other tasks) is:
+
+1. **Warp shuffle reduction builtins** (v0.8, small effort): Add `__shfl_xor_sync` and `__shfl_down_sync` to `builtins_cuda.ml`. These enable efficient intra-warp reductions without shared memory, benefiting layernorm, softmax, and loss kernels. Prerequisite: multi-threaded kernels from gh-ocannl-412.
+
+2. **GELU activation** (v0.7.1, trivial): Add to `nn_blocks.ml`. Needed for any GPT-2/transformer training example.
+
+3. **AdamW optimizer** (v0.7.1, small effort): Add to `train.ml` alongside existing SGD. Essential for transformer training. Pattern is well-known: per-parameter first/second moment tracking with weight decay decoupled from gradient.
+
+4. **Fused reduction code generation** (v0.8, medium effort): Teach the code generator to emit efficient parallel reductions for operations that reduce across dimensions (layernorm variance, softmax normalization). This extends gh-ocannl-412's parallel loop mapping to handle reduction patterns specifically.
+
+5. **Vectorized memory access** (v0.8, medium effort): Generate `float4` loads/stores for coalesced memory access in generated CUDA kernels. Deferred in gh-ocannl-412 but identified as a follow-up. llm.c's usage provides concrete patterns.
+
+6. **Learning rate scheduling and gradient clipping** (v0.7.1-v0.8, small effort): Higher-level training utilities for `train.ml`. Needed for realistic training examples.
+
+7. **Mixed precision infrastructure** (v0.9+, large effort): fp32 master weights with bf16 compute. Architecturally significant -- requires tracking two copies of parameters with different precisions.

--- a/docs/proposals/gh-ocannl-277.md
+++ b/docs/proposals/gh-ocannl-277.md
@@ -1,0 +1,158 @@
+# Proposal: Study krnl and autograph for Lessons Applicable to OCANNL
+
+**Task**: gh-ocannl-277
+**Issue**: https://github.com/ahrefs/ocannl/issues/277
+**Milestone**: v0.8
+
+## Goal
+
+Produce a structured comparative analysis of [krnl](https://github.com/charles-r-earp/krnl) (a Rust GPGPU kernel framework using Vulkan/SPIR-V) and [autograph](https://github.com/charles-r-earp/autograph) (an ML library built on krnl), evaluating their design decisions against OCANNL's architecture and identifying any transferable lessons. The analysis also includes a comparison with [Luminal](https://github.com/jafioti/luminal) (a graph-compiler ML framework in Rust) as requested in the original issue. The deliverable is a written analysis document, not code changes.
+
+## Acceptance Criteria
+
+- [ ] A written analysis document (`docs/krnl-autograph-analysis.md`) covering the subsystems listed in the Context section below
+- [ ] krnl's Vulkan/SPIR-V kernel model is assessed for portability lessons relevant to OCANNL's multi-backend architecture (CUDA, Metal, C)
+- [ ] autograph's tensor serialization and model composition patterns are compared against OCANNL's existing and planned capabilities (especially gh-ocannl-373 tensor persistence)
+- [ ] A three-way architectural comparison: krnl/autograph (eager-mode, Vulkan) vs Luminal (graph compiler, CUDA/Metal) vs OCANNL (einsum IR, code generation) -- identifying where each approach has advantages and disadvantages
+- [ ] Each identified technique or pattern is classified as: (a) already addressed by OCANNL or an existing task, (b) applicable and recommended with target milestone, or (c) not applicable with rationale
+- [ ] For category (b) items, concrete recommendations specify which OCANNL module/file would be affected and at what level of effort
+- [ ] A summary table mapping krnl/autograph features to OCANNL equivalents or gaps
+
+## Context
+
+### What krnl Is
+
+krnl is a Rust GPGPU framework that uses **Vulkan 1.2** as its compute backend, compiling kernels to **SPIR-V** via `spirv-builder` (using `rust-gpu`). Key characteristics:
+- Cross-platform GPU compute through Vulkan (Windows, Linux, macOS via MoltenVK)
+- Iterator-based kernel dispatch model: kernels are defined as Rust functions operating on slices/iterators, then JIT-compiled to SPIR-V
+- Device management abstracted behind a `Device` API
+- Supports `u8` through `f32` scalar types; no half-precision
+- Small project (last significant activity ~2024), primarily a proof of concept
+
+### What autograph Is
+
+autograph is an ML library built on top of krnl:
+- Tensor type emulating `ndarray::Array` API semantics
+- Autograd (automatic differentiation) with a tape-based system
+- `#[derive(Layer)]` and `#[derive(Forward)]` proc macros for model composition
+- `serde` serialization for tensors, models, and optimizer state
+- Layer types: Dense, Conv2d, with ReLU activation
+- Optimizer: SGD (with learning rate parameter)
+- Small scope: MNIST-level examples, proof-of-concept quality
+
+### What Luminal Is
+
+Luminal is a Rust ML framework with a graph-compiler approach:
+- Computation defined as a lazy graph, then compiled and optimized before execution
+- Backend plugins: CUDA, Metal, with optimization passes (kernel fusion, memory planning)
+- Graph rewriting for optimizations (similar in spirit to OCANNL's IR optimization)
+- Metal backend with shader compilation
+- More mature than krnl/autograph but still experimental
+
+### Subsystems to Analyze
+
+**1. Vulkan/SPIR-V as a portable GPU backend**
+- krnl's approach: single API (Vulkan) targeting all GPUs vs OCANNL's native CUDA + Metal
+- Portability vs performance tradeoff
+- Relevance: OCANNL already has multiple native backends; could Vulkan serve as a universal fallback?
+- Related: gh-ocannl-301 (IREE deep dive, which also has a Vulkan backend)
+
+**2. Kernel dispatch model**
+- krnl's iterator-based kernel definition vs OCANNL's einsum-to-loop-nest code generation
+- How krnl maps Rust iterators to GPU threads
+- Luminal's graph-level kernel fusion vs OCANNL's megakernel approach (gh-ocannl-318)
+
+**3. Serialization and persistence**
+- autograph's serde-based tensor/model/optimizer serialization
+- How this compares to OCANNL's planned tensor persistence (gh-ocannl-373)
+- Whether serde-style derive macros have an OCaml equivalent pattern (ppx)
+
+**4. Model composition patterns**
+- autograph's derive macros for Layer/Forward composition
+- Luminal's graph-based model definition
+- Comparison with OCANNL's functional composition in `nn_blocks.ml`
+
+**5. Memory management**
+- krnl's Vulkan buffer management vs OCANNL's per-backend allocation
+- Luminal's memory planning pass
+- Relevance to OCANNL's pool allocator plans (gh-ocannl-344)
+
+### OCANNL Architecture Constraints
+
+Key constraints affecting which lessons transfer:
+
+1. **Generated kernels, not hand-written.** OCANNL generates C/CUDA/Metal from the `Low_level.t` IR. Any technique must be expressible as an IR transformation or code generation pattern.
+
+2. **Einsum-based computation model.** Operations are specified as einsum contractions. krnl's iterator model and Luminal's graph nodes are different abstraction levels.
+
+3. **Single-threaded kernels (current state).** All CUDA kernels run with `grid_dim=1, block_dim=1`. The tiling proposal (gh-ocannl-412) is the prerequisite for GPU parallelism.
+
+4. **Multi-backend from day one.** OCANNL already targets C, CUDA, and Metal through a parameterized `C_syntax` module. This is architecturally closer to krnl's cross-platform goal than to Luminal's backend-specific plugins.
+
+### Related Tasks and Documents
+
+| Document/Task | Relevance |
+|---------------|-----------|
+| `docs/proposals/gh-ocannl-253.md` | llm.c study -- same "study external project" format |
+| `docs/proposals/gh-ocannl-412.md` | Tiling proposal -- krnl's parallelism model is relevant context |
+| gh-ocannl-373 | Tensor persistence -- autograph's serde patterns are directly relevant |
+| gh-ocannl-301 | IREE deep dive -- IREE also uses Vulkan/SPIR-V |
+| gh-ocannl-265 | Candle study -- another Rust ML framework comparison |
+| gh-ocannl-318 | Megakernels -- Luminal's kernel fusion is a comparison point |
+| `docs/megakernel-deep-dive.md` | Existing megakernel analysis |
+
+## Approach
+
+### Phase 1: krnl Source Study (half day)
+
+Read and analyze the krnl repository:
+- `krnl/` core: Device abstraction, buffer management, kernel dispatch
+- `krnl-macros/`: The `#[module]` proc macro that compiles Rust to SPIR-V
+- `spirv-builder` integration: How Rust code becomes GPU kernels
+- Performance characteristics: What does Vulkan cost vs native CUDA?
+
+Document:
+- The kernel dispatch model and how it maps to GPU execution
+- Vulkan buffer management patterns
+- Limitations (no half-precision, limited kernel expressiveness)
+
+### Phase 2: autograph Source Study (half day)
+
+Read and analyze the autograph repository:
+- Tensor implementation: How it wraps krnl buffers with ndarray-like semantics
+- Autograd tape: How gradients are tracked and computed
+- Serialization: The serde derive patterns for tensors, models, optimizers
+- Layer composition: The `#[derive(Layer)]` and `#[derive(Forward)]` macros
+
+Focus on:
+- Serialization patterns that could inform gh-ocannl-373
+- Whether the model composition approach has advantages over OCANNL's functional style
+
+### Phase 3: Luminal Comparison (half day)
+
+Read and analyze Luminal's architecture:
+- Graph definition and compilation pipeline
+- Optimization passes (fusion, memory planning)
+- CUDA and Metal backend implementations
+- How it compares to OCANNL's IR-based approach
+
+### Phase 4: Write Analysis Document (half day)
+
+Produce `docs/krnl-autograph-analysis.md` with:
+- Executive summary
+- Per-subsystem analysis sections (one per subsystem from Context above)
+- Three-way comparison table: krnl/autograph vs Luminal vs OCANNL
+- Recommendations table: technique, applicability, target milestone, effort
+- Architectural insights: what OCANNL's approach handles better, and where other approaches reveal gaps
+
+### Expected Findings (Preliminary Assessment)
+
+Based on the task elaboration, the likely high-value findings are:
+
+1. **Vulkan as universal fallback** (v1.0+, exploratory): krnl demonstrates that Vulkan can serve as a single GPU compute API. However, the performance gap vs native CUDA is significant, and OCANNL already has native backends. The main lesson is whether a Vulkan/SPIR-V path could replace the Metal backend for broader portability. Likely conclusion: not worth the complexity given OCANNL's existing multi-backend architecture, but the IREE deep dive (gh-ocannl-301) may revisit this.
+
+2. **Serialization patterns for tensor persistence** (v0.7.0, relevant): autograph's serde-based approach is clean and composable. The OCaml equivalent would be ppx-derived serializers. This directly informs gh-ocannl-373's design.
+
+3. **Graph-level fusion vs IR-level megakernels** (v0.8, context): Luminal's graph rewriting approach is conceptually similar to OCANNL's megakernel plans but operates at a higher abstraction level. Comparing the two can clarify where OCANNL should fuse (IR level) vs where graph-level reasoning is needed.
+
+4. **Limitations as lessons** (general): Both krnl and autograph are small, proof-of-concept projects that stopped at MNIST-level capability. Understanding why they didn't scale is itself a lesson -- likely related to the overhead of Vulkan abstraction and limited kernel expressiveness. OCANNL's code generation approach avoids these limitations.

--- a/docs/proposals/gh-ocannl-281.md
+++ b/docs/proposals/gh-ocannl-281.md
@@ -1,0 +1,38 @@
+# Collapse Repeated Identifiers in debug_name
+
+## Goal
+
+When a tensor's `label` list contains consecutive identical identifiers (e.g. `["attention"; "attention"; "attention"]`), `get_debug_name` should collapse them into a count-suffixed form (e.g. `"attention3"`) instead of producing verbose names like `"attention_attention_attention"`. This keeps debug output readable as issue #210 (incorporating runtime argument labels) introduces label repetition.
+
+Tracked by: https://github.com/ahrefs/ocannl/issues/281
+
+## Acceptance Criteria
+
+- Consecutive identical components in the filtered label list are collapsed with a numeric suffix: N identical copies of `"foo"` become `"fooN"` (for N >= 2).
+- A single (non-repeated) component is left unchanged (no `"foo1"` suffix).
+- Non-consecutive duplicates are not collapsed: `["a"; "b"; "a"]` remains `"a_b_a"`.
+- Mixed sequences work correctly: `["encoder"; "attention"; "attention"; "output"]` produces `"encoder_attention2_output"`.
+- The collapsing applies only to the alphanumeric-filtered components, before the `_`-join and before the grad suffix logic.
+- Existing tests pass (expected outputs in `test/operations/*.expected` may need updating if any current labels exhibit consecutive repetition).
+
+## Context
+
+### Current implementation
+
+`get_debug_name` in `arrayjit/lib/tnode.ml` (lines 121-139):
+
+1. If `code_name` is set, uses it directly (with `.grad` suffix handling).
+2. Otherwise, filters `label` through `is_alphanum_` to keep only alphanumeric components.
+3. Strips a leading `"grad"` component and tracks `is_grad`.
+4. Joins remaining components with `"_"` via `String.concat ~sep:"_"`.
+5. Appends `.grad` if applicable.
+
+The collapsing step should be inserted between step 3 (grad stripping) and step 4 (concatenation), operating on the `components` list.
+
+### Approach
+
+Add a helper function (e.g. `collapse_consecutive`) that folds over the string list, grouping consecutive equal elements and emitting `ident` for count=1 or `identN` for count>=2. Apply it to `components` before the `String.concat` call. This is a self-contained change to `tnode.ml` with no API changes.
+
+### Related
+
+- **#210**: Incorporate runtime argument labels -- the feature that motivates this collapsing.

--- a/docs/proposals/gh-ocannl-291.md
+++ b/docs/proposals/gh-ocannl-291.md
@@ -1,0 +1,99 @@
+# Audit manually specifying sharing in tensor node memory modes
+
+GitHub issue: [ahrefs/ocannl#291](https://github.com/ahrefs/ocannl/issues/291)
+
+## Goal
+
+Audit the correctness of manually specifying the `sharing` property (`Per_stream` vs `Shared_cross_streams`) on tensor node memory modes, identify bugs or inconsistencies between manual specification and the inference/allocation machinery, and either fix issues or document limitations. Since multi-streaming was removed (#341), the "shared cross-stream but updated from multiple streams" scenario from the original issue is largely moot -- the audit focuses on whether manual sharing specification works correctly in the current single-stream-per-device context and whether dead sharing code should be cleaned up.
+
+## Acceptance Criteria
+
+- [ ] **Manual sharing specification paths verified**: Confirm that calling `Tn.update_memory_mode` with `On_device Shared_cross_streams` or `On_device Per_stream` before compilation correctly influences `alloc_if_needed` allocation behavior in `backends.ml`.
+- [ ] **update_memory_sharing consistency audit**: Verify all case arms in `update_memory_sharing` (tnode.ml lines 357-388) are reachable and correct; identify any arms that are dead code after multi-streaming removal.
+- [ ] **alloc_if_needed sharing logic audit**: Verify the three-way branch in `alloc_if_needed` (backends.ml lines 520-559) -- read-only/constant path, `known_shared_cross_streams` writable path, and per-stream fallback -- handles all manual specification cases correctly.
+- [ ] **Conflict detection audit**: Verify that manually specifying sharing as `Shared_cross_streams` on a node that is then written to by different streams produces a clear error (not silent corruption).
+- [ ] **Dead sharing code identified**: List sharing-related code that is unreachable after multi-streaming removal (cross-stream candidates, owner_stream tracking, shared_writer_streams synchronization in `backends.ml`) and file a cleanup issue if substantial.
+- [ ] **Test coverage assessed**: Determine whether existing tests exercise manual sharing specification; if not, add a minimal test or document why testing is impractical in the single-stream context.
+- [ ] **Documentation of current behavior**: Update code comments or docs to clarify the post-multi-streaming-removal semantics of `sharing` -- what `Shared_cross_streams` means when there is only one stream per device.
+
+## Context
+
+### Memory mode and sharing types (tnode.ml)
+
+The `sharing` type has three variants:
+- `Unset` -- not yet determined, will be inferred as `Per_stream` or `Shared_cross_streams`
+- `Per_stream` -- separate buffer per stream (each stream gets its own allocation)
+- `Shared_cross_streams` -- single buffer per device, reused across streams
+
+The `sharing` property appears embedded in:
+- `On_device of sharing` -- device-resident tensor with specified sharing
+- `Hosted (Changed_on_devices of sharing)` -- hosted tensor whose device copy has specified sharing
+
+Users can manually set sharing via:
+- `Tn.update_memory_mode tn (On_device Shared_cross_streams) provenance` -- directly on tnode
+- `Tn.update_memory_sharing tn Shared_cross_streams provenance` -- updates sharing while preserving the memory mode category
+- `Train.set_materialized` -- sets `Materialized` (sharing-agnostic, resolved later)
+- `Train.set_on_host` / `Train.set_hosted` -- sets hosted modes (sharing resolved via `Changed_on_devices Unset`)
+
+### Sharing inference in alloc_if_needed (backends.ml lines 495-559)
+
+The allocation logic in `alloc_if_needed` determines sharing at link time:
+1. **Read-only/constant nodes**: If not `known_non_cross_stream`, uses `cross_stream_candidates` hashtable to share a single buffer; calls `update_memory_sharing Shared_cross_streams 39`.
+2. **Writable + `known_shared_cross_streams`**: Requires an owner stream; looks up shared buffer from `cross_stream_candidates`; errors if written from multiple streams.
+3. **Writable + not shared**: Falls through to `update_memory_sharing Per_stream 410` and allocates a fresh buffer.
+
+Key concern from the original issue: If a user manually marks a node as `Shared_cross_streams` but the node is writable and appears in multiple streams, the code at line 543-550 raises a `User_error`. This is the intended safety check, but since multi-streaming is removed, the scenario cannot arise in practice.
+
+### Synchronization infrastructure (backends.ml)
+
+The `shared_writer_streams`, `host_reading_streams`, and related event-tracking machinery in `Add_buffer_retrieval_and_syncing` was designed for multi-stream synchronization. Key functions:
+- `wait_for_all` / `wait_for_ready` -- synchronize across streams before transfers
+- `to_host` -- checks `potentially_cross_stream` before host transfer
+- `update_writer_event` -- tracks writer events for cross-stream nodes
+- `sync_routine.pre` -- waits for cross-stream writer events before routine execution
+
+With single-stream-per-device, most of this synchronization code is technically unnecessary but harmless. The `potentially_cross_stream` predicate still fires for nodes without explicit `Per_stream` marking.
+
+### Related tasks and issues
+
+- **gh-ocannl-333**: Remove hosted memory mode entirely (would subsume much of the sharing complexity)
+- **gh-ocannl-341**: Multi-streaming removed (closed, "Not planned") -- makes cross-stream sharing moot
+- **gh-ocannl-296**: Low-level audit (adjacent concern, memory mode inference in `cleanup_virtual_llc`)
+
+### Code pointers
+
+- **Sharing types**: `arrayjit/lib/tnode.ml` lines 25-34
+- **Memory mode types**: `arrayjit/lib/tnode.ml` lines 47-65
+- **update_memory_mode**: `arrayjit/lib/tnode.ml` lines 306-352 (~46 case arms)
+- **update_memory_sharing**: `arrayjit/lib/tnode.ml` lines 357-388 (~12 case arms)
+- **Sharing predicates**: `known_shared_cross_streams`, `known_non_cross_stream`, `potentially_cross_stream` (tnode.ml lines 285-299)
+- **alloc_if_needed**: `arrayjit/lib/backends.ml` lines 495-559
+- **Synchronization**: `arrayjit/lib/backends.ml` lines 38-90 (`wait_for_all`, `to_host`, `update_writer_event`)
+- **Device ref type**: `arrayjit/lib/backend_intf.ml` lines 91-100 (`cross_stream_candidates`, `owner_stream`, `shared_writer_streams`)
+- **Metal backend sharing**: `arrayjit/lib/metal_backend.ml` line 764 (uses `cross_stream_candidates` for constant buffers)
+- **Train helpers**: `lib/train.ml` lines 63-182 (`set_on_host`, `set_materialized`, `set_hosted`, `set_virtual`)
+
+## Approach
+
+### Phase 1: Static analysis of sharing code paths
+
+1. Trace all call sites of `update_memory_sharing` (only 2: backends.ml lines 541 and 557) and `update_memory_mode` with sharing-carrying modes to build a complete map of how sharing gets set.
+2. For each case arm in `update_memory_sharing`, determine: (a) is it reachable in single-stream context? (b) is the behavior correct?
+3. Analyze the `alloc_if_needed` three-way branch for all combinations of manual sharing specification vs inference.
+
+### Phase 2: Identify dead code and simplification opportunities
+
+1. Catalog sharing-related infrastructure that is unreachable with single-stream-per-device: `owner_stream` tracking, `shared_writer_streams` synchronization, multi-stream `wait_for_all` patterns.
+2. Determine what simplifications are safe vs what should be preserved for potential future multi-stream reintroduction.
+3. Consider interaction with gh-ocannl-333 (hosted mode removal) -- if that lands first, much of the sharing complexity disappears.
+
+### Phase 3: Verify or add test coverage
+
+1. Check whether any existing test exercises manual sharing specification (search for explicit `On_device Shared_cross_streams` or `Per_stream` in test code -- current search shows none).
+2. Write a minimal test that manually sets sharing before compilation and verifies correct allocation behavior, or document why this is impractical in the current architecture.
+
+### Phase 4: Document findings and clean up
+
+1. Update code comments on `sharing` type and `update_memory_sharing` to reflect post-multi-streaming semantics.
+2. File cleanup issue for dead sharing infrastructure if warranted.
+3. Update task notes with complete audit findings.

--- a/docs/proposals/gh-ocannl-296.md
+++ b/docs/proposals/gh-ocannl-296.md
@@ -1,0 +1,74 @@
+# Write / Flesh-Out lowering_and_inlining.md and Audit low_level.ml
+
+Tracked by: https://github.com/ahrefs/ocannl/issues/296
+
+## Goal
+
+Complete the documentation in `docs/lowering_and_inlining.md` to accurately reflect the current state of `low_level.ml`, and audit `low_level.ml` for correctness issues, dead code, stale FIXMEs, and documentation gaps. The doc is already substantial (316 lines) but has drifted from the code; the audit resolves the `FIXME(#296)` markers in `low_level.ml` and captures any findings as follow-up issues.
+
+## Acceptance Criteria
+
+### Documentation (lowering_and_inlining.md)
+
+- [ ] **Accuracy pass**: Every code snippet, line-number reference, and behavioral claim in the doc matches the current source (1840 lines in `low_level.ml`).
+- [ ] **Missing sections added**:
+  - `Set_from_vec` / vector operations: the doc currently omits `Set_from_vec` handling in tracing, virtualization, inlining, and cleanup.
+  - `eliminate_common_subexpressions` (CSE pass): added in the pipeline after `simplify_llc`, not yet documented as a pipeline phase.
+  - `cse_equal_scalar`: alpha-equivalence comparison infrastructure (lines 1216-1292).
+  - `substitute_float` / `substitute_proc`: scalar substitution helpers used in `simplify_llc` (lines 969-1004).
+  - `loop_over_dims`, `unroll_dims`, `loop_over_padding_region`: utility functions for generating loop nests and padding-region iteration (lines 1695-1840).
+  - `input_and_output_nodes`: how the optimizer determines which tensors are inputs vs outputs (lines 1367-1386).
+  - `optimize` entry point vs `optimize_proc`: the `optimize` wrapper that hooks up pretty-printing callbacks (lines 1688-1693).
+  - `Scope_id` module and `get_scope` UID generation.
+  - `Get_merge_buffer` and merge-buffer single-buffer constraint.
+  - `optimize_ctx` type and its role carrying `computations` across compilation calls.
+- [ ] **Pipeline diagram updated**: Current doc shows `visit_llc -> virtual_llc -> cleanup_virtual_llc -> simplify_llc`. Actual pipeline is `visit_llc -> virtual_llc -> cleanup_virtual_llc -> simplify_llc -> eliminate_common_subexpressions`.
+- [ ] **Settings section updated**: `inline_complex_computations` default changed from `false` to `true` in the current code (line 134). The doc still says "default: false".
+- [ ] **Non_virtual exit codes updated**: Code 52 (Concat in check_idcs) and 140 (vec ops) are in the code but 52 is missing from the doc's list.
+- [ ] **FIXME(#296) markers documented**: Each of the 5 `FIXME(#296)` sites (lines 874, 885, 891, 900, 928 in `cleanup_virtual_llc`) should be explained in the doc -- they mark places where the cleanup phase forces Virtual memory mode with specific provenance codes (15, 151, 152) for tensors not yet proven non-virtual, and one TODO about asserting Never_virtual.
+
+### Audit (low_level.ml)
+
+- [ ] **Resolve FIXME(#296) markers**: For each of the 5 `FIXME(#296)` comments, determine whether the current behavior is correct or needs a code change. If correct, replace the FIXME with an explanatory comment. If incorrect, file a follow-up issue.
+- [ ] **TODO(#296) at line 928**: Evaluate whether the `Get` case in `cleanup_virtual_llc.loop_scalar` can indeed assert `Never_virtual` instead of calling `update_memory_mode`. If safe, convert to assert; otherwise document why not.
+- [ ] **Dead code check**: Identify any unreachable match arms or functions in `low_level.ml`.
+- [ ] **Edge cases**: Verify behavior when `dims` is empty (relevant to `Set_from_vec` tracing at line 341), when `computations` list is empty at inline time, and when `check_and_store_virtual` encounters `Concat` indices.
+- [ ] **Audit findings documented**: All findings recorded in the task notes section, with follow-up issues filed for any bugs found.
+
+## Context
+
+### Current State of the Documentation
+
+`docs/lowering_and_inlining.md` (316 lines) already covers:
+- Low-level representation types (`t`, `scalar_t`, `scalar_arg`)
+- Index types (`axis_index` including `Affine` and `Concat`)
+- Translation from `Assignments` (projections to loops, symbol freshening, concatenation conversion)
+- Optimization pipeline phases (tracing, virtualization, inlining, cleanup, simplification)
+- Memory mode management
+- Virtualize settings
+- Limitations (affine index restriction #133, CSE gap #351)
+- Code generation integration
+
+The doc is high-quality but has fallen behind the code: the CSE pass was added but not documented, `Set_from_vec` support was added across the pipeline, and several defaults changed.
+
+### Key Source Files
+
+- **`arrayjit/lib/low_level.ml`** (1840 lines) -- IR types, optimization pipeline, pretty-printing
+- **`arrayjit/lib/assignments.ml`** (988 lines) -- High-level assignment representation, `to_low_level` translation
+- **`docs/lowering_and_inlining.md`** (316 lines) -- Existing documentation
+
+### FIXME(#296) Sites in low_level.ml
+
+All 5 markers are in `cleanup_virtual_llc` (lines 860-967):
+
+1. **Line 874** (`For_loop` case): When a for-loop's symbol maps to a tnode in `reverse_node_map` that is not known non-virtual, forces `Virtual 15` and removes the loop. FIXME suggests this may be too aggressive.
+2. **Line 885** (`Zero_out` case): Forces `Virtual 151` for non-virtual tnodes. Same concern.
+3. **Line 891** (`Set` case): Forces `Virtual 152` for non-virtual tnodes. Same concern.
+4. **Line 900** (`Set_from_vec` case): Forces `Virtual 152` for non-virtual tnodes. Same concern.
+5. **Line 928** (`Get` in `loop_scalar`): Sets `Never_virtual 17`. TODO suggests this should already be `Never_virtual` by this point and could be an assert.
+
+### Related Issues
+
+- **#133**: Affine index virtualization (multiple non-static symbols) -- doc mentions this limitation
+- **#134**: Virtual tensors sharing for-loops -- affects `reverse_node_map` shared-symbol tracking
+- **#351**: CSE after inlining -- the CSE pass is now implemented but doc doesn't reflect it

--- a/docs/proposals/gh-ocannl-308.md
+++ b/docs/proposals/gh-ocannl-308.md
@@ -1,0 +1,88 @@
+# Sasha Rush Tensor Puzzles in OCANNL
+
+**Issue:** [ahrefs/ocannl#308](https://github.com/ahrefs/ocannl/issues/308)
+**Status:** Proposal
+
+## Goal
+
+Solve the [Sasha Rush Tensor Puzzles](https://github.com/srush/Tensor-Puzzles) that map naturally to OCANNL's extended einsum notation, and provide clear explanations for those that do not fit. The deliverable is a documented analysis (posted as a GitHub issue comment and committed as a test/example file) that showcases OCANNL's einsum expressiveness and identifies gaps.
+
+## Acceptance Criteria
+
+- [ ] All 21 puzzles categorized into three tiers: (1) solvable with OCANNL einsum/`%op`, (2) solvable with OCANNL ops but requiring workarounds, (3) not expressible
+- [ ] Working OCANNL code for every solvable puzzle, preferring einsum notation where possible, committed as a test file `test/einsum/tensor_puzzles.ml` with inline expect tests verifying correctness on small inputs
+- [ ] For each non-expressible puzzle, a concise explanation of which OCANNL capability is missing (dynamic indexing, scan/prefix-sum, reshape, etc.)
+- [ ] A summary table identifying which missing capabilities would be most impactful to add, with links to existing issues where applicable
+- [ ] The full analysis posted as a comment on GitHub issue #308
+
+## Context
+
+### What the puzzles are
+
+Sasha Rush's Tensor Puzzles are 21 exercises that reimplement standard NumPy/PyTorch functions using only broadcasting, `arange(i)`, `where(q, a, b)`, arithmetic/comparison operators, and `@` (matmul). They teach tensor programming from first principles through broadcasting tricks.
+
+### OCANNL's relevant capabilities
+
+OCANNL's extended einsum provides:
+- Three axis kinds: `batch | input -> output`
+- Row variables (`...`) for broadcasting
+- Axis concatenation (`^`) for stacking and slicing
+- Affine indexing (`stride*out+kernel`, `stride*out<+kernel`) for convolutions
+- Pointwise ops: arithmetic, comparison (`<`, `=`, `<>`), logic (`&&`, `||`, `not`), `where`
+- Reduction operators: `++` / `+++` (sum), `@^^` (max), `++^` (concatenation)
+- `range_of_shape` for creating tensors filled with index values
+
+### Classification of puzzles
+
+| # | Puzzle | OCANNL Status | Key mechanism |
+|---|--------|---------------|---------------|
+| 1 | `ones` | **Einsum** | Constant tensor |
+| 2 | `sum` | **Einsum** | `+++ " => 0"` reduction |
+| 3 | `outer` | **Einsum** | `+* "i;j => ij"` outer product |
+| 4 | `diag` | Not expressible | Needs diagonal extraction (repeated index = trace, not diag) |
+| 5 | `eye` | **Workaround** | `range_of_shape` comparison: `where(i = j, 1, 0)` |
+| 6 | `triu` | **Workaround** | `range_of_shape` comparison: `where(i <= j, 1, 0)` |
+| 7 | `cumsum` | Not expressible | Loop-carried dependency, needs scan primitive |
+| 8 | `diff` | **Workaround** | Convolution with kernel `[1, -1]` via affine indexing |
+| 9 | `vstack` | **Einsum** | Concatenation: `++^ "a; b => a^b"` |
+| 10 | `roll` | Not expressible | Circular shift needs modular dynamic indexing |
+| 11 | `flip` | Not expressible | Reversed indexing `a[n-1-i]` not in affine spec |
+| 12 | `compress` | Not expressible | Prefix-sum for output positions + scatter |
+| 13 | `pad_to` | **Workaround** | Concatenation `^` for padding, axis slicing for truncation |
+| 14 | `sequence_mask` | **Workaround** | `where(j_index < length[i], values[i][j], 0)` via broadcasting |
+| 15 | `bincount` | Not expressible | Scatter-add with tensor values as indices |
+| 16 | `scatter_add` | Not expressible | Dynamic indexing: `out[link[j]] += values[j]` |
+| 17 | `flatten` | Not expressible | Reshape between differently-shaped tensors |
+| 18 | `linspace` | **Workaround** | Arithmetic on `range_of_shape` index values |
+| 19 | `heaviside` | **Einsum** | Pointwise `where(a = 0, b, where(a > 0, 1, 0))` |
+| 20 | `repeat` | **Einsum** | Broadcasting: batch axis expansion |
+| 21 | `bucketize` | **Einsum** | Broadcast compare + sum: `(v >= boundaries) +++ "i,j => i"` |
+
+**Summary:** 7 solvable with einsum, 6 with workarounds (13 total), 8 not expressible.
+
+### Missing capabilities identified
+
+| Missing Capability | Unlocks Puzzles | Impact |
+|--------------------|-----------------|--------|
+| **Gather/scatter (dynamic indexing)** | #4 diag, #15 bincount, #16 scatter_add, #12 compress | High -- needed for embedding lookup, attention, many real ML ops |
+| **Scan/prefix-sum** | #7 cumsum, #12 compress | Medium -- sequence processing, CTC loss |
+| **Reverse/flip indexing** | #11 flip | Low -- negative-stride affine extension |
+| **Circular shift** | #10 roll | Low -- modular affine index |
+| **Reshape/flatten** | #17 flatten | Medium -- tensor reshaping between views |
+
+### Approach
+
+1. Create `test/einsum/tensor_puzzles.ml` with inline expect tests, one `%expect_test` per solvable puzzle
+2. Each puzzle solution uses `%op` syntax with einsum notation where possible, falling back to `TDSL`/`NTDSL` operations where needed
+3. Use `range_of_shape` to create index-value tensors for workaround puzzles (eye, triu, sequence_mask, linspace)
+4. Use `++^` concatenation for vstack and pad_to
+5. Use affine convolution indexing for diff (kernel `[1, -1]`)
+6. Include comments explaining the non-expressible puzzles inline
+7. Post the full classification table and code as a comment on issue #308
+
+### Key design decisions
+
+- **Test file, not documentation**: Solutions live as executable tests, ensuring they stay correct as OCANNL evolves
+- **Float domain**: All puzzles are solved in OCANNL's float domain; integer-semantic puzzles (bincount, scatter_add) are noted as requiring float-to-int casting awareness
+- **Boundary conditions**: Puzzle #8 (diff) first element handling -- the convolution naturally handles boundaries via valid-convolution semantics (output shorter than input) or padding
+- **No new primitives**: This task is purely about demonstrating what OCANNL can already do and documenting the gaps; no new operations are added

--- a/docs/proposals/gh-ocannl-313.md
+++ b/docs/proposals/gh-ocannl-313.md
@@ -1,0 +1,110 @@
+# Proposal: Get MSVC to work on the C backend for native Windows
+
+**Task**: gh-ocannl-313
+**Issue**: https://github.com/ahrefs/ocannl/issues/313
+
+## Goal
+
+Enable OCANNL's C backend (`cc_backend.ml`) to compile generated C code using MSVC (`cl.exe`) on native Windows, load the resulting DLL, and execute compiled functions -- without regressing GCC/Clang compilation on Unix.
+
+## Acceptance Criteria
+
+- MSVC (`cl.exe`) can compile OCANNL-generated C code into a DLL
+- The compiled DLL is loaded and functions are called successfully via ctypes
+- MSVC compiler flags are correctly formatted (`/O2 /LD` not `-O3 -shared`)
+- GCC/Clang compilation on Unix is not affected (no regressions)
+- At least one OCANNL test passes end-to-end on Windows with MSVC
+
+## Context
+
+### Current compilation pipeline
+
+The C backend lives in two files:
+- `arrayjit/lib/cc_backend.ml` -- compiler invocation, dynamic loading, linking
+- `arrayjit/lib/c_syntax.ml` -- C code generation (AST to PPrint documents)
+
+The compilation flow:
+1. `compile` / `compile_batch` generates a `.c` file via `C_syntax.compile_proc`
+2. `c_compile_and_load` shells out to the system C compiler (detected via `ocamlc -config`)
+3. The resulting `.so` / `.dll` is loaded with `Dl.dlopen` + `RTLD_NOW`
+4. Functions are looked up via `Foreign.foreign ~from:lib name`
+
+### What already works on Windows
+
+- File extension handling: `.dll` on `Sys.win32` (lines 71, 74)
+- Null device: `nul` on `Sys.win32` (line 140)
+- OS type detection: `Sys.os_type` match includes `"Win32"` and `"Cygwin"` cases (line 83)
+
+### What does NOT work with MSVC
+
+**1. Compiler flags (cc_backend.ml lines 86-101)**
+The current flag construction is entirely GCC-style:
+- `-O3` optimization (MSVC uses `/O2`)
+- `-march=native` arch flags (MSVC uses `/arch:AVX2` or similar)
+- `-ffast-math` (MSVC uses `/fp:fast`)
+- `-shared` / `-bundle` link flags (MSVC uses `/LD`)
+- `-o output.dll` (MSVC uses `/Fe:output.dll`)
+
+**2. DLL symbol export**
+GCC with `-shared` exports all symbols by default. MSVC does NOT -- functions must be marked `__declspec(dllexport)` or listed in a `.def` file. Without this, `GetProcAddress` (used by ctypes' `Foreign.foreign`) cannot find the compiled functions.
+
+The function header is generated in `c_syntax.ml` line 803-805:
+```ocaml
+let func_header =
+  string B.main_kernel_prefix ^^ space ^^ string "void" ^^ space ^^ string name
+```
+For the CC backend, `main_kernel_prefix` is `""` (set in `Pure_C_config`). This needs to become `__declspec(dllexport)` on MSVC/Windows.
+
+**3. Dynamic library loading**
+`Dl.dlopen` (line 150) wraps POSIX `dlopen`. On Windows, ctypes' `Dl` module maps to `LoadLibrary`/`GetProcAddress`, which should work if ctypes was compiled with Windows support. This needs verification but is likely a non-issue.
+
+### Generated C code portability
+
+The generated C code is standard C99 with no GCC extensions (`__attribute__`, `__builtin_*`, inline assembly). MSVC 2015+ supports the required C99 subset. The builtins in `builtins_cc.ml` use portable constructs (bit manipulation for half/bfloat16/fp8 emulation, standard math functions). No changes to generated C code are expected beyond the export decoration.
+
+### Key code locations
+
+| What | File | Lines |
+|------|------|-------|
+| Compiler command detection | `cc_backend.ml` | 23-41 |
+| Compilation + loading | `cc_backend.ml` | 62-153 |
+| Platform-specific link flags | `cc_backend.ml` | 77-85 |
+| Compiler flags (optimization, arch, fast-math) | `cc_backend.ml` | 87-97 |
+| Command line assembly | `cc_backend.ml` | 98-101 |
+| Dynamic loading | `cc_backend.ml` | 150 |
+| Function header generation | `c_syntax.ml` | 803-805 |
+| `main_kernel_prefix` (empty for CC) | `cc_backend.ml` | 160 (via `Pure_C_config`) |
+| C includes / builtins | `builtins_cc.ml` | 1-10 |
+
+## Approach
+
+### 1. Detect MSVC vs GCC-compatible compiler
+
+Add a `compiler_family` type and detection in `cc_backend.ml`. Detection based on `ocamlc -config` output: if the C compiler path contains `cl` or `cl.exe` (without a preceding `-` or `/`), it is MSVC. Expose as a function so other parts can query it.
+
+### 2. Branch compiler flag construction
+
+In `c_compile_and_load`, build the command line differently for MSVC:
+
+| GCC/Clang | MSVC |
+|-----------|------|
+| `-O3` | `/O2` (max is `/O2`; `/Ox` for full) |
+| `-shared -fPIC` | `/LD` |
+| `-o output.dll` | `/Fe:output.dll` |
+| `-march=native` | `/arch:AVX2` (or empty) |
+| `-ffast-math` | `/fp:fast` |
+| `-bundle -undefined dynamic_lookup` | N/A (macOS only) |
+
+### 3. Add `__declspec(dllexport)` to generated functions on Windows
+
+Modify `main_kernel_prefix` in the CC backend's `Pure_C_config` to return `"__declspec(dllexport)"` when `Sys.win32` is true, or `""` otherwise. This is the minimal change -- the field already exists and is concatenated before `void` in the function signature.
+
+### 4. Verify `Dl.dlopen` on Windows
+
+OCaml ctypes' `Dl` module should map to `LoadLibrary` on Windows. If it does not, provide a fallback using `Ctypes.Foreign` or direct FFI to `LoadLibraryA`/`GetProcAddress`. This is a verification step -- likely no code change needed.
+
+### 5. Handle MSVC-specific edge cases
+
+- MSVC generates `.lib` and `.exp` files alongside `.dll` -- temp file cleanup should handle these
+- MSVC debug builds produce `.pdb` files -- not relevant for optimized compilation
+- Minimum version: MSVC 2015 (v14.0) for C99 compound literal support

--- a/docs/proposals/gh-ocannl-313.md
+++ b/docs/proposals/gh-ocannl-313.md
@@ -12,55 +12,61 @@ Enable OCANNL's C backend (`cc_backend.ml`) to compile generated C code using MS
 - MSVC (`cl.exe`) can compile OCANNL-generated C code into a DLL
 - The compiled DLL is loaded and functions are called successfully via ctypes
 - MSVC compiler flags are correctly formatted (`/O2 /LD` not `-O3 -shared`)
+- Dynamic library loading works on Windows (ctypes `Dl.dlopen` maps to `LoadLibrary`)
 - GCC/Clang compilation on Unix is not affected (no regressions)
 - At least one OCANNL test passes end-to-end on Windows with MSVC
+- Generated function signatures include `__declspec(dllexport)` on Windows so symbols are visible to `GetProcAddress`
 
 ## Context
 
 ### Current compilation pipeline
 
-The C backend lives in two files:
+The C backend lives in three key files:
 - `arrayjit/lib/cc_backend.ml` -- compiler invocation, dynamic loading, linking
-- `arrayjit/lib/c_syntax.ml` -- C code generation (AST to PPrint documents)
+- `arrayjit/lib/c_syntax.ml` -- C code generation (PPrint-based AST to C text)
+- `arrayjit/lib/builtins_cc.ml` -- C builtins (float16/bfloat16/fp8 emulation, threefry PRNG, vector types)
 
 The compilation flow:
-1. `compile` / `compile_batch` generates a `.c` file via `C_syntax.compile_proc`
-2. `c_compile_and_load` shells out to the system C compiler (detected via `ocamlc -config`)
-3. The resulting `.so` / `.dll` is loaded with `Dl.dlopen` + `RTLD_NOW`
-4. Functions are looked up via `Foreign.foreign ~from:lib name`
+1. `compile` / `compile_batch` generates a `.c` file via `C_syntax.compile_proc` + `filter_and_prepend_builtins`
+2. `c_compile_and_load` (cc_backend.ml:62-153) shells out to the system C compiler
+3. Compiler detected via `ocamlc -config` field `c_compiler:` (cc_backend.ml:23-41)
+4. The resulting `.so`/`.dll` is loaded with `Dl.dlopen ~flags:[RTLD_NOW]` (line 150)
+5. Functions are looked up via `Foreign.foreign ~from:lib name` (line 391)
 
 ### What already works on Windows
 
-- File extension handling: `.dll` on `Sys.win32` (lines 71, 74)
+- File extension: `.dll` on `Sys.win32` (lines 71, 74)
 - Null device: `nul` on `Sys.win32` (line 140)
-- OS type detection: `Sys.os_type` match includes `"Win32"` and `"Cygwin"` cases (line 83)
+- OS type detection: `Sys.os_type` match includes `"Win32"` and `"Cygwin"` cases (line 83), but uses GCC-style `-shared` flag
 
 ### What does NOT work with MSVC
 
-**1. Compiler flags (cc_backend.ml lines 86-101)**
-The current flag construction is entirely GCC-style:
-- `-O3` optimization (MSVC uses `/O2`)
-- `-march=native` arch flags (MSVC uses `/arch:AVX2` or similar)
-- `-ffast-math` (MSVC uses `/fp:fast`)
-- `-shared` / `-bundle` link flags (MSVC uses `/LD`)
-- `-o output.dll` (MSVC uses `/Fe:output.dll`)
+**1. Compiler flags (cc_backend.ml:86-101)**
+The entire flag construction is GCC-specific:
+- `compiler_flags` (line 88-96): `-O3`, `-march=native`, `-ffast-math` -- all GCC syntax
+- `kernel_link_flags` (line 77-85): `-shared -fPIC` on Linux, `-bundle` on macOS, `-shared` on Win32 -- the Win32 case uses GCC/MinGW syntax, not MSVC
+- `cmdline` (line 98-100): `compiler f_path flags -o libname link_flags` -- MSVC uses different argument ordering and `/` prefix flags
 
-**2. DLL symbol export**
-GCC with `-shared` exports all symbols by default. MSVC does NOT -- functions must be marked `__declspec(dllexport)` or listed in a `.def` file. Without this, `GetProcAddress` (used by ctypes' `Foreign.foreign`) cannot find the compiled functions.
-
-The function header is generated in `c_syntax.ml` line 803-805:
+**2. DLL symbol export (c_syntax.ml:803-805)**
+GCC with `-shared` exports all symbols by default. MSVC does NOT. Functions must be marked `__declspec(dllexport)` or a `.def` file must be provided. The function header is generated as:
 ```ocaml
-let func_header =
-  string B.main_kernel_prefix ^^ space ^^ string "void" ^^ space ^^ string name
+string B.main_kernel_prefix ^^ space ^^ string "void" ^^ space ^^ string name
 ```
-For the CC backend, `main_kernel_prefix` is `""` (set in `Pure_C_config`). This needs to become `__declspec(dllexport)` on MSVC/Windows.
+For CC backend, `main_kernel_prefix` is `""` (set in `Pure_C_config`, c_syntax.ml:90). On Windows/MSVC this needs to become `"__declspec(dllexport)"`.
 
-**3. Dynamic library loading**
-`Dl.dlopen` (line 150) wraps POSIX `dlopen`. On Windows, ctypes' `Dl` module maps to `LoadLibrary`/`GetProcAddress`, which should work if ctypes was compiled with Windows support. This needs verification but is likely a non-issue.
+**3. Dynamic library loading (cc_backend.ml:150)**
+`Dl.dlopen` wraps POSIX `dlopen`. The OCaml ctypes library's `Dl` module maps to `LoadLibrary`/`GetProcAddress` on Windows when ctypes is compiled with Windows support. This needs verification but is likely a non-issue since ctypes is actively maintained cross-platform.
 
-### Generated C code portability
+### Generated C code portability assessment
 
-The generated C code is standard C99 with no GCC extensions (`__attribute__`, `__builtin_*`, inline assembly). MSVC 2015+ supports the required C99 subset. The builtins in `builtins_cc.ml` use portable constructs (bit manipulation for half/bfloat16/fp8 emulation, standard math functions). No changes to generated C code are expected beyond the export decoration.
+The generated C code is standard C99 -- no GCC extensions found:
+- No `__attribute__`, `__builtin_*`, inline assembly, or VLAs
+- Standard headers only: `stdio.h`, `math.h`, `stdint.h`, `string.h`, `stdlib.h`
+- Math functions used (`fmax`, `fmin`, `ldexpf`, `fabsf`, `isinf`, `isnan`) all available in MSVC
+- Type punning via `memcpy` and pointer cast (`*((float *)&u32)`) works on MSVC
+- Half/BFloat16/FP8 emulation uses portable bit manipulation
+
+**One caveat in `builtins_cc.ml`**: The `HALF_TO_UINT16` and `UINT16_TO_HALF` macros (lines 73, 82) use GCC statement expressions (`({ ... })`), but only inside `#if HAS_NATIVE_FLOAT16` guards. Since MSVC does not define `__FLT16_MAX__`, `HAS_NATIVE_FLOAT16` will be 0, so these macros are never compiled on MSVC. No change needed.
 
 ### Key code locations
 
@@ -71,40 +77,95 @@ The generated C code is standard C99 with no GCC extensions (`__attribute__`, `_
 | Platform-specific link flags | `cc_backend.ml` | 77-85 |
 | Compiler flags (optimization, arch, fast-math) | `cc_backend.ml` | 87-97 |
 | Command line assembly | `cc_backend.ml` | 98-101 |
-| Dynamic loading | `cc_backend.ml` | 150 |
+| Dynamic loading (`Dl.dlopen`) | `cc_backend.ml` | 150 |
+| Function linking (`Foreign.foreign`) | `cc_backend.ml` | 391 |
 | Function header generation | `c_syntax.ml` | 803-805 |
-| `main_kernel_prefix` (empty for CC) | `cc_backend.ml` | 160 (via `Pure_C_config`) |
-| C includes / builtins | `builtins_cc.ml` | 1-10 |
+| `main_kernel_prefix` (empty for CC) | `c_syntax.ml` | 90 |
+| C includes/builtins | `builtins_cc.ml` | 1-10 |
+| `builtins.c` (C stubs, same float16 macros) | `arrayjit/lib/builtins.c` | 1-32 |
+| Dune config (foreign_stubs) | `arrayjit/lib/dune` | 37-39 |
 
 ## Approach
 
-### 1. Detect MSVC vs GCC-compatible compiler
+### 1. Add compiler family detection (cc_backend.ml)
 
-Add a `compiler_family` type and detection in `cc_backend.ml`. Detection based on `ocamlc -config` output: if the C compiler path contains `cl` or `cl.exe` (without a preceding `-` or `/`), it is MSVC. Expose as a function so other parts can query it.
+Add a `compiler_family` type and detection function:
 
-### 2. Branch compiler flag construction
+```ocaml
+type compiler_family = GCC_compatible | MSVC
 
-In `c_compile_and_load`, build the command line differently for MSVC:
+let detect_compiler_family () =
+  let cmd = compiler_command () in
+  (* MSVC toolchain: cl.exe or cl *)
+  if String.is_substring cmd ~substring:"cl.exe"
+     || (String.is_suffix cmd ~suffix:"cl"
+         && not (String.is_substring cmd ~substring:"clang")) then
+    MSVC
+  else GCC_compatible
+```
 
-| GCC/Clang | MSVC |
-|-----------|------|
-| `-O3` | `/O2` (max is `/O2`; `/Ox` for full) |
-| `-shared -fPIC` | `/LD` |
-| `-o output.dll` | `/Fe:output.dll` |
-| `-march=native` | `/arch:AVX2` (or empty) |
-| `-ffast-math` | `/fp:fast` |
-| `-bundle -undefined dynamic_lookup` | N/A (macOS only) |
+Expose this so `Pure_C_config` can also use it for setting `main_kernel_prefix`.
 
-### 3. Add `__declspec(dllexport)` to generated functions on Windows
+### 2. Branch compiler flag construction (cc_backend.ml:77-101)
 
-Modify `main_kernel_prefix` in the CC backend's `Pure_C_config` to return `"__declspec(dllexport)"` when `Sys.win32` is true, or `""` otherwise. This is the minimal change -- the field already exists and is concatenated before `void` in the function signature.
+Replace the current monolithic flag+cmdline construction with a compiler-family branch:
 
-### 4. Verify `Dl.dlopen` on Windows
+**Link flags:**
+- GCC/Clang: `-shared -fPIC` (Linux), `-bundle -undefined dynamic_lookup` (macOS)
+- MSVC: `/LD` (create DLL)
 
-OCaml ctypes' `Dl` module should map to `LoadLibrary` on Windows. If it does not, provide a fallback using `Ctypes.Foreign` or direct FFI to `LoadLibraryA`/`GetProcAddress`. This is a verification step -- likely no code change needed.
+**Compiler flags:**
+| GCC/Clang | MSVC | Notes |
+|-----------|------|-------|
+| `-O3` | `/O2` | MSVC max optimization; `/Ox` for full |
+| `-march=native` | `/arch:AVX2` or empty | Config-driven, default empty for MSVC |
+| `-ffast-math` | `/fp:fast` | |
+| `-fPIC` | (not needed) | Windows DLLs always position-independent |
 
-### 5. Handle MSVC-specific edge cases
+**Command line format:**
+- GCC: `cc source.c -O3 -march=native -o output.so -shared -fPIC > log 2>&1`
+- MSVC: `cl.exe /O2 /LD /Fe:output.dll source.c > log 2>&1`
 
-- MSVC generates `.lib` and `.exp` files alongside `.dll` -- temp file cleanup should handle these
-- MSVC debug builds produce `.pdb` files -- not relevant for optimized compilation
-- Minimum version: MSVC 2015 (v14.0) for C99 compound literal support
+### 3. Add `__declspec(dllexport)` to generated functions (c_syntax.ml)
+
+Modify `Pure_C_config` to set `main_kernel_prefix`:
+
+```ocaml
+let main_kernel_prefix =
+  if Sys.win32 then "__declspec(dllexport)" else ""
+```
+
+This uses the existing `main_kernel_prefix` mechanism (already used by CUDA for `extern "C" __global__` and Metal for `kernel`). The field is concatenated before `void` in the function signature at c_syntax.ml:804.
+
+### 4. Handle MSVC auxiliary file cleanup (cc_backend.ml)
+
+MSVC generates `.lib` and `.exp` files alongside `.dll`. Add cleanup of these files:
+- After successful compilation, remove `base_name.lib` and `base_name.exp`
+- On compilation failure, include these in cleanup too
+
+### 5. Add MSVC arch flag configuration (cc_backend.ml)
+
+The `arch_flags` setting (line 20) defaults to `-march=native` which is GCC-only. For MSVC, default to empty string (MSVC auto-detects) or allow `/arch:AVX2` via the existing `cc_backend_arch_flags` config:
+
+```ocaml
+let arch_flags () =
+  let default = match detect_compiler_family () with
+    | GCC_compatible -> "-march=native"
+    | MSVC -> ""  (* MSVC auto-detects; user can set /arch:AVX2 *)
+  in
+  Utils.get_global_arg ~default ~arg_name:"cc_backend_arch_flags"
+```
+
+### 6. Verify and test
+
+- Verify `Dl.dlopen` maps to `LoadLibrary` on Windows (read ctypes source or test)
+- If ctypes `Dl` does not support Windows, provide a fallback (unlikely needed)
+- Run existing tests on Windows with MSVC toolchain
+- Ensure `builtins.c` (the OCaml C stubs, not the generated builtins) compiles with MSVC via dune -- dune handles this via `(foreign_stubs)` which respects `ocamlc -config` compiler
+
+### Edge cases
+
+- **MinGW vs MSVC on Windows**: If OCaml is built with MinGW-GCC, `ocamlc -config` returns `gcc` and existing code works fine. The MSVC path only activates when OCaml uses MSVC toolchain.
+- **MSVC version**: Require MSVC 2015 (v14.0)+ for C99 compound literal and mixed declaration support.
+- **Clang-cl**: Microsoft's `clang-cl` accepts both `/` and `-` flags. The GCC-compatible path should work but may need minor adjustments. This is a follow-up concern.
+- **`builtins.c` GCC statement expressions**: Lines 20-21 use `({ ... })` inside `#if HAS_NATIVE_FLOAT16` which MSVC won't compile. But MSVC never defines `__FLT16_MAX__` so `HAS_NATIVE_FLOAT16=0` and those macros are not compiled. Same applies to `builtins_cc.ml` lines 73, 82.

--- a/docs/proposals/gh-ocannl-333.md
+++ b/docs/proposals/gh-ocannl-333.md
@@ -1,0 +1,71 @@
+# Proposal: Remove hosted memory mode and Ndarray dependency from Tnode
+
+GitHub issue: [ahrefs/ocannl#333](https://github.com/ahrefs/ocannl/issues/333)
+
+## Goal
+
+Eliminate the dual host/device memory model by removing the `array` field from `Tnode.t`, the `Hosted` variant from `memory_mode`, and the `memory_type` type entirely. All tensor data lives exclusively on devices; CPU-side value access (printing, saving, inspection) happens via on-demand device-to-host transfers through a context. The `Ndarray` module is retained as a slimmed-down utility for temporary host buffers but is no longer stored inside tensor nodes.
+
+## Acceptance Criteria
+
+1. **`array` field removed from `Tnode.t`**: The `array : Nd.t option Lazy.t` field (tnode.ml line 74) is deleted. No host-side copy is stored in the tensor node.
+
+2. **`Hosted` variant and `memory_type` removed**: The `Hosted of memory_type` variant is deleted from `memory_mode`. The `memory_type` type (`Unset_hosted`, `Constant`, `Nonconstant`, `Changed_on_devices`, `Volatile`) is deleted entirely. `Materialized` collapses to mean `On_device`.
+
+3. **`devices_not_lagging_host` removed**: The host/device sync tracking field (tnode.ml line 94) and all `prepare_read`/`prepare_write` callback machinery are removed.
+
+4. **Context-based value access**: `get_value`, `set_value`, `get_values`, `set_values` (tnode.ml lines 810-844) are replaced with context-aware versions that perform on-demand device-to-host transfers. An optional `mutable host_cache : Nd.t option` field on `Tnode.t` allows evictable caching (mutable, not lazy, per the issue author's comment about future buffer eviction).
+
+5. **On-demand tensor printing**: `Tensor.print` works without hosted arrays. The `[%cd "for_print" =: t_to_print]` trick creates a temporary device-to-host copy. A cache of for-print tensor nodes avoids recompilation. This is off by default for `Tensor.print`, on by default for `Train.printf`.
+
+6. **Train.ml cleanup**: `set_on_host`, `set_hosted`, `every_non_literal_on_host` are deleted. The `?(hosted = true)` parameter is removed from `to_routine`, `init_params`, `run_once`, `forward_once`. `forward` and `grad_update` stop calling `set_hosted`.
+
+7. **Parameter initialization works**: Parameters are initialized by writing to a temporary host buffer then copying to device via `from_host`, rather than the current pattern of writing to the hosted array.
+
+8. **`.@` operators updated**: The `Operation.At` operators (`.@{}` and `.@{}<-`) are migrated to context-aware access. Since these appear in only ~7 call sites (operation.ml, two test files, docs), the migration scope is contained.
+
+9. **Backend interface preserved**: `from_host` and `to_host` backend operations continue to work. `to_host` becomes the primary retrieval path. `use_host_memory` flag for Apple Silicon unified memory stays.
+
+10. **`Ndarray` module minimized**: Functions only used through the hosted array pattern are removed. Core functions needed for temporary host buffers are retained: `create_array`, `render_array`, `retrieve_flat_values`, `set_flat_values`, precision handling.
+
+11. **No regression in existing tests**: All tests pass after the refactoring.
+
+## Context
+
+### Current architecture
+
+`Tnode.t` maintains a dual-memory model where tensor nodes can have both a host-side `Ndarray` (the `array` field) and device-side buffers managed by backends. The `Hosted of memory_type` memory mode controls synchronization between host and device copies, with five `memory_type` sub-variants driving a complex state machine in `update_memory_mode` (tnode.ml lines 306-352) and `update_memory_sharing` (tnode.ml lines 357-388).
+
+Key code locations:
+- **Tnode.t type**: arrayjit/lib/tnode.ml lines 73-98 (record with `array`, `devices_not_lagging_host`)
+- **memory_mode/memory_type**: arrayjit/lib/tnode.ml lines 36-65
+- **Value access**: arrayjit/lib/tnode.ml lines 809-844 (`get_value`, `set_value`, `get_values`, `set_values`)
+- **Mode transitions**: arrayjit/lib/tnode.ml lines 306-388 (~49 `Hosted` references in tnode.ml)
+- **Backend transfers**: arrayjit/lib/backends.ml (`to_host`, `from_host`)
+- **Train helpers**: lib/train.ml (`set_on_host`, `set_hosted`, `every_non_literal_on_host`)
+- **Low-level compilation**: arrayjit/lib/low_level.ml (2 `Hosted` references in mode assignment)
+- **Ndarray module**: arrayjit/lib/ndarray.ml (~772 lines)
+
+### Design rationale (from issue author)
+
+The author's comments clarify the progression of thinking:
+1. Initially: make everything materialized also hosted on-demand, with mutable (not lazy) caching for future eviction
+2. Final position: "we will make **nothing** hosted, printing, saving, and accessing selected values will perform on-demand retrieving from the devices"
+3. The printing trick `[%cd "for_print" =: t_to_print]` with a cache of for-print nodes avoids the `set_materialized` problem
+
+### Scope boundaries
+
+**In scope**: Removing `array` field, `Hosted` variant, `memory_type` type, host/device sync tracking, Train.ml hosted helpers, updating value access to require context, implementing on-demand printing, updating all tests and examples, minimizing Ndarray.
+
+**Out of scope**: Full Ndarray module removal (still needed for precision-polymorphic host buffers), buffer eviction policy design (future work enabled by this change), unified memory optimization (orthogonal), `from_host`/`to_host` backend signature changes.
+
+### Impact estimate
+
+This is a large refactoring touching ~50+ locations across tnode.ml, low_level.ml, backends.ml, train.ml, tensor.ml, operation.ml, and test files. The API change (adding `~ctx` to value access) propagates to all downstream callers. The `update_memory_mode` state machine shrinks significantly with `Hosted` removal.
+
+### Edge cases
+
+- **Printing without context**: Before compilation, tensor printing shows shape/metadata only (no values). A "print context" pattern or lazy printing can address interactive use.
+- **Parameter serialization**: The disabled `save_params`/`restore_params` in train.ml needs redesign around context-based device-to-host-to-disk path.
+- **Virtual/Local tnodes**: These have no device buffers. Printing requires materializing first.
+- **C backend**: cc_backend.ml uses `Lazy.force tn.array` for compiled C function parameter binding -- must switch to context array map.

--- a/docs/proposals/gh-ocannl-340.md
+++ b/docs/proposals/gh-ocannl-340.md
@@ -1,0 +1,146 @@
+# Proposal: Track whether Local_scope variables need initialization
+
+**Issue**: https://github.com/ahrefs/ocannl/issues/340
+
+## Goal
+
+Eliminate unnecessary zero-initialization of `Local_scope` scalar variables in generated C code. Currently, every `Local_scope` variable is unconditionally zero-initialized (e.g., `float v42 = 0.0;`), but initialization is only needed when the variable is **recurrent** -- i.e., read before its first write (accumulator pattern: `v42 = v42 + delta`). The tracing infrastructure already detects this via `read_before_write` on `traced_array`; the missing piece is threading that flag into the `Local_scope` IR node and using it in code generation.
+
+## Acceptance Criteria
+
+- A `needs_init : bool` field is added to the `Local_scope` variant in `scalar_t` (both `low_level.ml` and `low_level.mli`).
+- The field is populated from `traced_array.read_before_write` during `Local_scope` creation in `virtual_llc`.
+- When `needs_init = false`, `c_syntax.ml` emits the declaration without zero-initialization (e.g., `float v42;` instead of `float v42 = (float)0;`).
+- When `needs_init = true`, zero-initialization is preserved (no regression for accumulator patterns).
+- The `TODO(#340)` comment in `c_syntax.ml` line 519 is removed.
+- All existing tests pass (no regression).
+- Conservative default: if the traced_array lookup fails, `needs_init` defaults to `true`.
+
+## Context
+
+### Current state: unconditional zero-init
+
+In `c_syntax.ml` lines 518-521, every `Local_scope` variable gets zero-initialized:
+
+```ocaml
+let init_zero =
+  (* TODO(#340): only do this in the rare cases where the computation is accumulating *)
+  let prefix, postfix = B.convert_precision ~from:Ops.int32 ~to_:scope_prec in
+  string " = " ^^ string prefix ^^ string "0" ^^ string postfix
+in
+```
+
+This produces C code like `float v42_some_var = (float)0;` even when the variable is immediately assigned before any read.
+
+### Existing detection infrastructure
+
+The tracing pass (`visit_llc`, called first in `optimize_proc` at line 1394) already tracks whether each tensor node is read before written:
+
+- **`traced_array.read_before_write`** (line 153): a `mutable bool` field, set to `true` at line 452 when any access position is `Recurrent`.
+- **`visits` type** (line 145): `Visits of int | Recurrent` -- a position is marked `Recurrent` via the `visit` function (line 191) when accessed before being assigned.
+- The `traced_store` hashtable, populated by `visit_llc`, is passed to `virtual_llc` where `Local_scope` is created.
+
+### Local_scope creation site
+
+In `virtual_llc` (line 775), `Local_scope` is created at lines 838-841:
+
+```ocaml
+let id = get_scope tn in
+Option.value ~default:llsc
+@@ Option.map (inline_computation ~id computations_table traced static_indices indices)
+     ~f:(fun body -> Local_scope { id; body; orig_indices = indices })
+```
+
+The `traced` variable (of type `traced_array`) is already in scope here -- obtained at line 835 via `get_node traced_store tn`. Its `read_before_write` field is already populated by the earlier tracing pass.
+
+### Downstream passes
+
+After `virtual_llc`, the IR passes through:
+1. `cleanup_virtual_llc` -- propagates `Local_scope` unchanged (line 933, 942)
+2. `simplify_llc` -- may eliminate `Local_scope` nodes (lines 1044-1053) or propagate via `{ opts with body = ... }`
+3. `eliminate_common_subexpressions` -- may replace duplicate `Local_scope` with `Get_local` (lines 1304-1311)
+
+All of these use record update (`{ opts with ... }`) or pattern match with wildcards, so adding a new field requires only that propagation code preserves it. The simplification pass that eliminates `Local_scope` entirely (lines 1044-1050) doesn't need the field since the local variable ceases to exist.
+
+### Backend scope
+
+Only `c_syntax.ml` handles `Local_scope` for code generation (lines 514-528 for code gen, line 646 for debug output). The CUDA and Metal backends do not directly pattern-match on `Local_scope`.
+
+### Related issue
+
+gh-ocannl-420 addresses unnecessary `Zero_out` for arrays (a different level of initialization). This issue (#340) addresses unnecessary zero-init for scalar local variables. They are complementary optimizations.
+
+## Approach
+
+### 1. Add `needs_init` field to `Local_scope`
+
+In `low_level.ml` line 53 and `low_level.mli` line 45, extend the record:
+
+```ocaml
+| Local_scope of { id : scope_id; body : t; orig_indices : Indexing.axis_index array; needs_init : bool }
+```
+
+### 2. Populate at creation site
+
+In `virtual_llc` at line 841, use `traced.read_before_write`:
+
+```ocaml
+~f:(fun body -> Local_scope { id; body; orig_indices = indices; needs_init = traced.read_before_write })
+```
+
+At line 842-844 (the existing `Local_scope` propagation case), preserve the field via `{ opts with body = ... }` (already the pattern used).
+
+### 3. Update c_syntax.ml
+
+At line 514, add `needs_init` to the pattern match. At lines 518-521, conditionally emit zero-init:
+
+```ocaml
+| Local_scope { id = { tn = { prec = scope_prec; _ }; scope_id } as id; body; orig_indices = _; needs_init } ->
+    let scope_prec = Lazy.force scope_prec in
+    let num_typ = string (B.typ_of_prec scope_prec) in
+    let init_zero =
+      if needs_init then
+        let prefix, postfix = B.convert_precision ~from:Ops.int32 ~to_:scope_prec in
+        string " = " ^^ string prefix ^^ string "0" ^^ string postfix
+      else
+        empty
+    in
+```
+
+Remove the `TODO(#340)` comment.
+
+### 4. Update all pattern matches in low_level.ml
+
+~20 locations in `low_level.ml` pattern-match on `Local_scope`. Most fall into two categories:
+
+- **Wildcard the field** (read-only traversals): lines 72, 202, 222, 243, 396, 564, 1200, 1270-1271. These use `{ id; body; _ }` or similar -- already wildcard `orig_indices`, so no change needed if already using `_`.
+- **Propagate the field** (transformations that rebuild `Local_scope`): lines 724-730, 933-942, 978, 1028-1053, 1304-1311. Most use `{ opts with body = ... }` which automatically preserves `needs_init`. The explicit record constructions at lines 724-730 and 1311 need `needs_init` added.
+
+### 5. Handle inline_computation (lines 724-730)
+
+This creates a new `Local_scope` inside `inline_computation` when transforming nested scopes. The `needs_init` from the original should be preserved:
+
+```ocaml
+| Local_scope { id; body; orig_indices; needs_init } ->
+    Local_scope
+      {
+        id;
+        body = Option.value_exn ~here:[%here] @@ loop env body;
+        orig_indices = Array.map ~f:(subst env) orig_indices;
+        needs_init;
+      }
+```
+
+### 6. Handle CSE pass (lines 1304-1311)
+
+The CSE pass rebuilds `Local_scope` after processing the body. Propagate `needs_init`:
+
+```ocaml
+| Local_scope { id; body; orig_indices; needs_init } ->
+    ...
+    let result = Local_scope { id; body; orig_indices; needs_init } in
+```
+
+### 7. Update expected test outputs
+
+If any `.expected` test files show the zero-initialization pattern for non-recurrent `Local_scope` variables, they will need updating to reflect the removed `= (float)0` initializers. Run the test suite and update `.expected` files as needed.

--- a/docs/proposals/gh-ocannl-343.md
+++ b/docs/proposals/gh-ocannl-343.md
@@ -1,0 +1,249 @@
+# Proposal: Optimize One-Hot Encoding Pattern for Embeddings
+
+## Goal
+
+Eliminate the computational waste of materializing full one-hot matrices for embedding lookups. Currently, embedding lookup `C[X]` in OCANNL requires pre-computing one-hot vectors on the CPU, transferring the (much larger) one-hot matrix to the device, and performing a full matrix multiply -- O(vocab_size) work per token when O(1) suffices. This optimization adds a virtual one-hot mechanism via a new `Equality_with_index` fetch op that never materializes the sparse matrix, and adds a pattern-based optimization in `low_level.ml` that collapses the resulting for-loop into a direct row lookup.
+
+GitHub issue: https://github.com/ahrefs/ocannl/issues/343
+
+## Acceptance Criteria
+
+- [ ] New `Equality_with_index` fetch op in `assignments.ml` that represents "1.0 if offset == embedded_index, else 0.0" without allocating a dense one-hot matrix
+- [ ] `one_hot_virtual` function in `operation.ml` (or `nn_blocks.ml`) that creates a virtual one-hot tensor using `Equality_with_index`, taking only the index tensor and number of classes -- no Bigarray allocation
+- [ ] Pattern detection in `low_level.ml` `simplify_llc`: when a for-loop accumulates `equality_result * table[k, ...]` over index `k`, replace with a direct lookup `table[index_value, ...]`, eliminating the loop entirely
+- [ ] The `bigram_mlp.ml` test updated to use `one_hot_virtual` instead of pre-computed one-hot matrices, with identical training results (loss values match within float32 tolerance)
+- [ ] Memory usage for the embedding input is proportional to batch_size (one int-as-float per token), not batch_size * vocab_size
+- [ ] Backward pass works correctly: gradient through the virtual one-hot uses the same pattern in reverse (the one-hot transpose backward is acceptable for the first implementation, since that matches current behavior)
+- [ ] No regression in existing tests
+- [ ] The optimization fires and is observable: generated C code for the optimized path contains a direct array index (cast-to-int of a float value) rather than a reduction loop over vocab_size
+
+## Context
+
+### The one-hot inefficiency
+
+For a vocabulary of size V and batch of size B with embedding dimension D:
+- **Current one-hot approach**: Allocates B*V floats (e.g., 50K vocab * 512 batch = 25M floats = 100MB), most are zeros. Then does B*V*D multiplies.
+- **After optimization**: Index tensor is B floats. The for-loop over V with conditional multiply is replaced by a direct lookup. In the generated code: `result[batch][dim] = table[(int)index[batch]][dim]`.
+
+### Current embedding patterns in OCANNL
+
+**Pre-computed one-hot** (`test/training/bigram_mlp.ml` lines 13-24):
+```ocaml
+let tensor_of_int_list lst =
+  let genarray = Genarray.create Float32 c_layout [| len; dict_size |] in
+  for i = 0 to len - 1 do
+    Genarray.set genarray [| i; arr.(i) |] 1.
+  done;
+  TDSL.rebatch ~l:"tensor" (Ir.Ndarray.as_array Ir.Ops.Single genarray) ()
+```
+
+**FSM transformer** (`test/training/fsm_transformer.ml` lines 51-59): Same pattern, flat one-hot arrays.
+
+**nn_blocks helper** (`lib/nn_blocks.ml` lines 61-76): `one_hot_of_int_list ~num_classes` -- pre-computes a dense Bigarray.
+
+All of these create dense B*V float arrays on the CPU before any computation.
+
+### Key code pointers
+
+- **`fetch_op` type** (`arrayjit/lib/assignments.ml:24-41`): Where the new `Equality_with_index` variant goes. Current variants include `Range_over_offsets`, `Embed_symbol`, `Constant`, etc.
+- **`to_low_level`** (`arrayjit/lib/assignments.ml:190+`): Where `fetch_op` variants are lowered to `Low_level.t` IR. The new variant's lowering generates `Cmpeq(Embed_index(offset), Get(index_tensor, batch_idcs))`.
+- **`simplify_llc`** (`arrayjit/lib/low_level.ml:1006-1214`): The scalar simplification pass where the pattern detection goes. Already handles constant folding, FMA fusion, etc.
+- **`axis_index` type** (`arrayjit/lib/indexing.ml:104-120`): Current index types: `Fixed_idx`, `Iterator`, `Affine`, `Sub_axis`, `Concat`. No changes needed for Phase 1.
+- **`scalar_t` / `Embed_index`** (`arrayjit/lib/low_level.ml:52-63`): `Embed_index` converts an `axis_index` to a scalar float -- this is how `Range_over_offsets` puts index values into computations.
+- **`c_syntax.ml` Embed_index** (`arrayjit/lib/c_syntax.ml:572-578`): How index-as-scalar renders in C code.
+
+### How the IR looks today (one-hot * embedding matrix)
+
+When the einsum `{ w_embed } * input` is lowered with a one-hot `input` tensor, the low-level IR is approximately:
+
+```
+For_loop { index = k; from_ = 0; to_ = vocab_size - 1;
+  body = Set { tn = result; idcs = [batch; dim];
+    llsc = Binop(Add,
+      Get_local acc,
+      Binop(Mul,
+        Get(one_hot_input, [batch; k]),      (* 0.0 or 1.0 *)
+        Get(embedding_table, [k; dim])))     (* table row *)
+  }
+}
+```
+
+### How the IR will look with virtual one-hot
+
+With `Equality_with_index`, the one-hot tensor is instead initialized via:
+```
+Fetch { array = virtual_onehot; fetch_op = Equality_with_index { index_tensor }; dims = ... }
+```
+
+Which lowers to:
+```
+For_loop { index = k; body =
+  Set { tn = virtual_onehot; idcs = [batch; k];
+    llsc = Binop(Cmpeq,
+      Embed_index(Iterator k),           (* the class index *)
+      Get(index_tensor, [batch]))        (* the index value *)
+  }
+}
+```
+
+After einsum with the embedding table, the reduction loop body becomes:
+```
+For_loop { index = k;
+  body = Set { tn = result; idcs = [batch; dim];
+    llsc = Binop(Add, Get_local acc,
+      Binop(Mul,
+        Binop(Cmpeq, Embed_index(Iterator k), Get(index_tensor, [batch_idx])),
+        Get(embedding_table, [k; dim])))
+  }
+}
+```
+
+The simplification pass detects this pattern and replaces it with:
+```
+Set { tn = result; idcs = [batch; dim];
+  llsc = Get(embedding_table, [cast_to_int(Get(index_tensor, [batch_idx])); dim])
+}
+```
+
+This eliminates the for-loop entirely.
+
+### Design choice: why `Equality_with_index` fetch op
+
+lukstafi considered three approaches in the GitHub discussion:
+
+1. **Low-level pattern detection only** (Approach A): Fragile, requires dynamic indexing in `indexing.ml`.
+2. **High-level `embedding` operation** (Approach B): Clean but requires new shape inference support.
+3. **Virtual one-hot / `Equality_with_index`** (Approach C): The selected approach. Reasons:
+   - No new `axis_index` variant needed (no `Dynamic_idx` in `indexing.ml`)
+   - No new shape inference rules
+   - Works with existing einsum -- the virtual one-hot participates in standard matrix multiply projections
+   - The optimization is a local pattern in `simplify_llc`, not a global restructuring
+   - Backward pass works automatically: the gradient of `w * one_hot` with respect to `w` uses the one-hot as-is (transposed), which is correct whether the one-hot is real or virtual
+
+The key insight: instead of adding dynamic indexing to the index system (which complicates shape inference and optimization), we keep indices static and add a fetch op that generates equality comparisons. The simplifier then recognizes that "sum over k of (k == index) * table[k]" is just "table[index]".
+
+## Approach
+
+### Phase 1: `Equality_with_index` fetch op and lowering
+
+**`arrayjit/lib/assignments.ml`**: Add to `fetch_op`:
+```ocaml
+| Equality_with_index of { index_tn : Tn.t }
+    (** Virtual one-hot: cell value is 1.0 if offset along the last axis equals
+        the value in [index_tn] at the corresponding batch position, else 0.0.
+        Shape: [index_tn.dims...; num_classes]. *)
+```
+
+**`assignments.ml` `to_low_level`**: Add lowering case. The tensor has dims `[..batch_dims; num_classes]`. The index tensor has dims `[..batch_dims]`. For each cell, compare the last-axis offset against the index tensor value at the batch position:
+```ocaml
+| Fetch { array; fetch_op = Equality_with_index { index_tn }; dims = (lazy dims) } ->
+    let num_classes = dims.(Array.length dims - 1) in
+    let batch_dims = Array.sub dims ~pos:0 ~len:(Array.length dims - 1) in
+    default_padding_before array
+    @@ Low_level.loop_over_dims dims ~body:(fun idcs ->
+        let batch_idcs = Array.sub idcs ~pos:0 ~len:(Array.length batch_dims) in
+        let class_idx = idcs.(Array.length idcs - 1) in
+        set array idcs @@
+          mk_binop Cmpeq
+            (Embed_index class_idx)
+            (Get (index_tn, batch_idcs)))
+```
+
+### Phase 2: Pattern detection in `simplify_llc`
+
+Add a new pass (or extend the existing `simplify_llc`) that recognizes the embedding lookup pattern in the low-level IR. The pattern to detect:
+
+```
+For_loop { index = k; from_ = 0; to_ = N-1;
+  body = Set { tn = result; idcs = result_idcs;
+    llsc = Binop(Add, Get_local acc,
+      Binop(Mul,
+        (Cmpeq(Embed_index(Iterator k), index_expr), _),
+        (Get(table, table_idcs_containing_k), _)))
+  }
+}
+```
+
+Where `k` appears exactly once in `table_idcs` as `Iterator k`. Replace with:
+```
+Set { tn = result; idcs = result_idcs;
+  llsc = Get(table, table_idcs_with_k_replaced_by_index_expr)
+}
+```
+
+This is a structural pattern match on the `For_loop` node, not on scalars. It should be a separate function called from the top-level `loop_proc` in `simplify_llc`, matching on `For_loop` nodes specifically.
+
+**Important**: the accumulation variable (`Get_local acc` / `Set_local`) wrapping must be handled. The pattern occurs inside a `Local_scope` that initializes the accumulator to 0.0 and accumulates with Add. The full pattern including the scope is:
+```
+Local_scope { id; body =
+  Set_local(id, Constant 0.0);  (* init *)
+  For_loop { index = k; ... body =
+    Set_local(id, Binop(Add, Get_local id,
+      Binop(Mul, cmpeq_pattern, table_get)))
+  }
+}
+```
+
+After optimization, this becomes:
+```
+Get(table, optimized_idcs)
+```
+
+(The entire Local_scope is replaced.)
+
+### Phase 3: Dynamic index in generated code
+
+The optimized IR contains `Get(table, [...; index_expr; ...])` where `index_expr` is something like `Get(index_tensor, batch_idcs)` -- a float value that needs to be cast to an integer index. This is a new pattern for `c_syntax.ml`: an axis index that is itself a scalar expression rather than a loop variable or constant.
+
+Options:
+- **Float-to-int cast in index position**: The simplifier can produce a `Get` where one index position is derived from a scalar expression. This requires either:
+  - A new `axis_index` variant `Dynamic of Tn.t * axis_index array` in `indexing.ml`, or
+  - Keeping the scalar expression as a `Get` nested inside the index computation.
+
+The cleanest approach: add `Dynamic of scalar_t` to `axis_index` in `indexing.ml`, where `scalar_t` is `Low_level.scalar_t`. This variant renders in `c_syntax.ml` as `(int)(scalar_expr)`.
+
+However, to minimize changes in Phase 1, an alternative: the simplifier can rewrite the pattern to use a fresh for-loop-free `Set` with the index tensor value embedded via `Embed_index` of a new `Dynamic_lookup` axis_index variant:
+```ocaml
+| Dynamic_lookup of { tn : Tn.t; idcs : axis_index array }
+    (** Index value is the integer conversion of the float at tn[idcs]. *)
+```
+
+This is the minimal addition to `indexing.ml` needed. It renders in c_syntax as `(int)(buffer[offset])`.
+
+### Phase 4: User-facing API
+
+**`lib/nn_blocks.ml`** or **`tensor/operation.ml`**: Add `one_hot_virtual`:
+```ocaml
+let one_hot_virtual ~num_classes index_tensor =
+  Tensor.term ~fetch_op:(Equality_with_index { index_tn = index_tensor.Tensor.value })
+    ~grad_spec:Prohibit_grad
+    ~batch_dims:(* inherit from index_tensor *)
+    ~input_dims:[ num_classes ] ~output_dims:[] ()
+```
+
+The function creates a virtual one-hot tensor that can be used in einsum expressions identically to a real one-hot tensor, but never materializes the dense matrix. When multiplied by an embedding table via einsum, the low-level optimizer collapses it to a direct lookup.
+
+Usage in `bigram_mlp.ml`:
+```ocaml
+(* Before: *)
+let inputs = tensor_of_int_list int_input in  (* allocates batch*vocab_size floats *)
+(* After: *)
+let index_tensor = (* batch-sized tensor of integer-as-float values *) in
+let inputs = one_hot_virtual ~num_classes:dict_size index_tensor in
+```
+
+### Phase 5: Backward pass
+
+The gradient of `w * one_hot` with respect to `w` is `grad_output * one_hot^T`. With virtual one-hot, this is:
+- `grad_w[k, d] += grad_output[batch, d] * cmpeq(k, index[batch])`
+
+This is the standard dense backward pass -- O(B * V * D). It is no worse than the current approach (the one-hot transpose multiply has the same complexity). Sparse gradient (scatter-add) is a follow-up optimization.
+
+The gradient with respect to the index tensor is zero (indices are not differentiable), which is handled by `grad_spec:Prohibit_grad` on the virtual one-hot tensor.
+
+### Risks and edge cases
+
+- **Float-to-int precision**: Index values stored as floats (e.g., 42.0) must cast cleanly to integers. For vocab sizes up to ~16M, float32 represents all integers exactly. GPT-2's 50257 is well within range.
+- **Out-of-bounds indices**: If `index_tensor` contains a value >= num_classes or < 0, the direct lookup accesses out-of-bounds memory. The `Equality_with_index` lowering naturally produces 0.0 for all classes (safe but silent). The optimized direct-lookup path must add bounds checking or document that indices must be valid.
+- **Pattern fragility**: The simplifier pattern match is structural. If the einsum lowering changes the IR shape (e.g., different accumulator pattern, different operation order), the pattern won't fire and the code falls back to the unoptimized but correct equality-comparison loop. This is a safe fallback.
+- **Interaction with virtualization/inlining**: The `Equality_with_index` tensor may be virtualized (inlined) by `low_level.ml`'s tracing pass, which would change the IR structure before `simplify_llc` runs. The pattern detection must account for both inlined and non-inlined forms, or the optimization should run before virtualization.

--- a/docs/proposals/gh-ocannl-344.md
+++ b/docs/proposals/gh-ocannl-344.md
@@ -1,0 +1,69 @@
+# Proposal: Implement a Universal Pool Allocator across backends
+
+GitHub issue: [ahrefs/ocannl#344](https://github.com/ahrefs/ocannl/issues/344)
+
+## Goal
+
+Replace per-tensor-node individual buffer allocations with a pool allocator that consolidates tensors into a small number of large pool buffers shared across all backends (Metal, CUDA, C). Each tensor is addressed as a `(pool_id, byte_offset)` pair within a pool buffer, rather than holding its own device pointer. This solves Metal's ~31 argument buffer binding limit, reduces allocation overhead, improves memory locality, and provides a natural place to introduce configurable 32-bit vs 64-bit index arithmetic via the `large_models` setting.
+
+## Acceptance Criteria
+
+1. **Pool allocator module**: A new `Pool_allocator` module (or extension of `backend_intf.ml`) provides a backend-agnostic pool allocation interface. Each pool has a backend-specific base pointer, a total size, and a bump/free-list allocator that returns `{ pool_id; offset; size_in_bytes }` records with configurable alignment.
+
+2. **`buffer_ptr` replaced by `buffer_offset`**: The `'buffer_ptr buffer` type in `backend_intf.ml` (line 7) is replaced by a `buffer_offset` record containing `pool_id : int`, `offset : int`, and `size_in_bytes : int`. The per-tnode map `ctx_arrays` (line 8) maps tnodes to `buffer_offset` values instead of raw backend pointers.
+
+3. **`ctx_arrays` renamed to `ctx_buffers`**: All occurrences of `ctx_arrays` across `backend_intf.ml`, `backend_impl.ml`, `metal_backend.ml`, `cuda_backend.ml`, `cc_backend.ml`, and all callers are renamed to `ctx_buffers`.
+
+4. **Pool-based allocation in all backends**: Each backend's `Alloc_buffer` implementation allocates from pools rather than making individual `mem_alloc` / `Buffer.on_device` / `allocate_n` calls:
+   - **Metal** (`metal_backend.ml` lines 75-83): `Me.Buffer.on_device` creates pool buffers, not per-tnode buffers.
+   - **CUDA** (`cuda_backend.ml` lines 62-71): `Cu.Deviceptr.mem_alloc` creates pool buffers.
+   - **C** (`backend_impl.ml` lines 44-72): `Ctypes.allocate_n` creates pool buffers.
+
+5. **Code generation emits pool base + offset access**: `c_syntax.ml` parameter generation (lines 760-800) emits pool base pointers as kernel arguments and offset constants (or additional arguments) instead of per-tnode pointer arguments. Generated C/Metal/CUDA code casts `(pool_base + offset)` to the appropriate typed pointer for each tensor access.
+
+6. **Metal binding count reduced**: Metal kernel dispatch (`metal_backend.ml` lines 757-785) binds O(num_pools) buffers via `set_buffer` instead of O(num_tnodes). Offsets are passed as kernel constants or a small argument buffer. This keeps total bindings well within Metal's 31-slot limit for models with hundreds of tensor nodes.
+
+7. **`large_models` setting controls index width**: The existing `big_models` setting in `Utils.settings` is renamed (or aliased) to `large_models`. When `large_models = true`, pool offsets and index arithmetic use `uint64_t` (supporting pools > 4 GB). When `false` (default), `uint32_t` is used. This affects `arg_int_prefix` and `loop_index_type` in `c_syntax.ml` (lines 94-95) and offset-related types in generated code.
+
+8. **Pool lifecycle management**: Pools are created at device/stream initialization with a configurable initial size. When a pool is exhausted, a new pool is allocated (pools are never resized, since that would invalidate offsets). Pools are freed when the owning device/stream is finalized. The `allocated_buffer` reuse pattern in `stream_ref` (line 111 of `backend_intf.ml`) is replaced by pool-level management.
+
+9. **Merge buffer integration**: The `merge_buffer` field on `stream_ref` (`backend_intf.ml` line 109) works with the pool allocator. Merge buffers can be allocated from a dedicated temporary pool or from the main pool with fast reclaim.
+
+10. **No regression in existing tests**: All existing tests pass after the refactoring.
+
+## Context
+
+### Why pool allocation is necessary
+
+Metal compute shaders have a hard limit of ~31 argument buffer bindings per compute command encoder. The current architecture binds one Metal buffer per tensor node (`metal_backend.ml` line 761: `Me.ComputeCommandEncoder.set_buffer encoder ~index buffer`), which fails for models with more than ~30 materialized tensors in a single kernel. A pool allocator consolidates all tensors into 1-3 large pool buffers, each bound once, with individual tensors addressed by offset arithmetic within the shader.
+
+### Current allocation architecture
+
+Each backend allocates buffers independently per tensor node. The `Alloc_buffer` module type (`backend_intf.ml` lines 26-35) defines `alloc_buffer`, `alloc_array`, `alloc_zeros`, and `free_buffer`. The `ctx_arrays` field (`backend_intf.ml` line 188) in the context type maps each tnode to a backend-specific `buffer_ptr`. At link time, each `Param_ptr tn` in the kernel parameter list causes a separate buffer binding.
+
+Key code paths affected:
+- **Parameter list construction**: `c_syntax.ml` line 773 -- each in-context tnode becomes a `Param_ptr tn` entry
+- **Metal dispatch**: `metal_backend.ml` lines 757-785 -- iterates `Param_ptr` params, calls `set_buffer` per tnode
+- **CUDA dispatch**: `cuda_backend.ml` line 949 -- iterates `Param_ptr` params, pushes device pointers as kernel args
+- **C dispatch**: `cc_backend.ml` line 400 -- iterates `Param_ptr` params, passes pointers to compiled function
+- **Buffer type**: `backend_intf.ml` line 7 -- `type 'buffer_ptr buffer = { ptr : 'buffer_ptr; size_in_bytes : int }`
+
+### Alignment requirements
+
+Pool sub-allocations must respect backend-specific alignment:
+- **Metal**: 256 bytes (page alignment preferred for private storage mode)
+- **CUDA**: 256 bytes (memory coalescing alignment)
+- **C/host**: 64 bytes (cache line alignment)
+
+### Relationship to other work
+
+- **gh-ocannl-333 (remove hosted memory)**: Pool allocation changes buffer management; synergistic with removing the host-side `array` field since device buffers become the sole storage.
+- **gh-ocannl-320 (Metal private mode)**: Entire pools get one storage mode, simplifying private mode adoption.
+- **gh-ocannl-340 (Local_scope init)**: Local tnodes with short lifetimes benefit from arena-style allocation within pools.
+
+### Naming conventions
+
+The issue requests renaming for consistency:
+- `ctx_arrays` -> `ctx_buffers` (these are device buffers, not arrays)
+- `buffer_ptr` -> `buffer_offset` (after pooling, individual tensors are offsets into pools)
+- `big_models` -> `large_models` (consistent with the issue's terminology)

--- a/docs/proposals/gh-ocannl-356.md
+++ b/docs/proposals/gh-ocannl-356.md
@@ -1,0 +1,60 @@
+# Proposal: Rename param/params to kparam/kparams
+
+**Task**: [gh-ocannl-356](https://github.com/ahrefs/ocannl/issues/356)
+**Status**: ready
+
+## Goal
+
+Eliminate the naming ambiguity between ML-level tensor parameters (`Tensor.params` -- trainable weights/biases) and kernel/routine parameters (`param_source`, `Param_ptr`, `procedure.params` -- buffer pointers and static indices passed to compiled compute kernels). Rename all kernel-parameter identifiers from `param`/`params` to `kparam`/`kparams` in the arrayjit backend layer.
+
+## Acceptance Criteria
+
+- [ ] `param_source` type renamed to `kparam_source` in `backend_intf.ml`
+- [ ] `Param_ptr` variant renamed to `Kparam_ptr`
+- [ ] `params` field renamed to `kparams` in all `procedure` record types (`cc_backend.ml`, `cuda_backend.ml`, `metal_backend.ml`)
+- [ ] `params_and_names` renamed to `kparams_and_names` in `cuda_backend.ml` `code_batch`
+- [ ] All local variable bindings, function parameters, and pattern matches referencing kernel params updated consistently across `c_syntax.ml`, `cc_backend.ml`, `cuda_backend.ml`, `metal_backend.ml`
+- [ ] `Tensor.params`, `Tensor.init_params`, and all tensor-layer naming is **unchanged**
+- [ ] `kernel_log_param`, `log_param_c_expr_doc`, `idx_params` (Indexing symbols), and other unrelated uses of "param" are **unchanged** -- only kernel buffer/source parameter identifiers are renamed
+- [ ] Comments referencing renamed identifiers are updated
+- [ ] Project compiles cleanly with no type errors
+- [ ] Existing test suite passes with no regressions
+
+## Context
+
+The codebase uses "params" for two distinct concepts:
+
+1. **Tensor parameters** (`Tensor.params`): trainable descendants whose `diff` is not `None` -- the ML sense of "parameters."
+2. **Kernel parameters** (`param_source`, `Param_ptr`, `procedure.params`): arguments passed to compiled compute kernels -- buffer pointers, merge buffers, log file names, static indices.
+
+Reading code like `List.iter params ~f:(fun (name, Param_ptr tn) -> ...)` is ambiguous. The `k` prefix ("kernel parameter") disambiguates concisely.
+
+### Scope
+
+The rename is confined to the arrayjit backend layer. Affected files:
+
+| File | Key changes |
+|------|-------------|
+| `arrayjit/lib/backend_intf.ml` | `param_source` -> `kparam_source`, `Param_ptr` -> `Kparam_ptr` |
+| `arrayjit/lib/c_syntax.ml` | `compile_proc` return type, local `params` bindings, `Param_ptr` patterns (~15 locations) |
+| `arrayjit/lib/cc_backend.ml` | `procedure.params` -> `kparams`, link function `params` arg, `Param_ptr` pattern |
+| `arrayjit/lib/cuda_backend.ml` | `procedure.params` -> `kparams`, `code_batch.params_and_names` -> `kparams_and_names`, `link_proc` signature, `Param_ptr` pattern |
+| `arrayjit/lib/metal_backend.ml` | `procedure.params` -> `kparams`, `code_batch.funcs` tuples, `link_proc` signature, `Param_ptr` patterns |
+
+### What is NOT renamed
+
+- `kernel_log_param` / `log_param_c_expr_doc` / `log_file_param` / `merge_param` -- these are about specific kernel parameter *kinds*, not the `param_source` type. They could optionally be prefixed but the task issue focuses on the `param`/`params` -> `kparam`/`kparams` rename for disambiguation from `Tensor.params`.
+- `idx_params` (bound symbols from `Indexing`) -- these are indexing symbols, not kernel parameter sources.
+- `CAMLparam*` in `builtins.c` -- OCaml C FFI macros, unrelated.
+- Any `Tensor`-layer code.
+
+### Approach
+
+This is a mechanical rename. OCaml's static type system will catch any missed references at compile time. The recommended workflow is:
+
+1. Rename the type and variant in `backend_intf.ml`
+2. Fix all compilation errors file by file
+3. Update comments referencing old names
+4. Run the test suite
+
+A single commit preserves git blame clarity.

--- a/docs/proposals/gh-ocannl-377.md
+++ b/docs/proposals/gh-ocannl-377.md
@@ -1,0 +1,180 @@
+# Proposal: GPT-2 Small Inference Pipeline
+
+## Goal
+
+Build an end-to-end inference pipeline for GPT-2 Small (124M parameters) that loads pre-trained weights into OCANNL, tokenizes input text, runs a decoder-only transformer forward pass, and generates coherent text autoregressively. This is the v0.7.1 milestone "Transformer inference demo (#377)" and serves as OCANNL's first real-world pre-trained model example.
+
+GitHub issue: https://github.com/ahrefs/ocannl/issues/377
+
+## Acceptance Criteria
+
+- [ ] GeLU activation added to `lib/nn_blocks.ml` using the tanh approximation composed from existing ops: `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))`
+- [ ] `decoder_only_block` added to `lib/nn_blocks.ml`: pre-layer-norm, masked self-attention, GeLU FFN, configurable activation, no cross-attention
+- [ ] `decoder_only_transformer` added to `lib/nn_blocks.ml`: stacks N blocks with final layer norm, accepts learned positional embeddings
+- [ ] Python weight conversion script (`scripts/convert_gpt2_weights.py`) downloads GPT-2 Small from HuggingFace, splits fused QKV weights, transposes Conv1D-style matrices, and writes OCANNL checkpoint format (s-expression header + binary)
+- [ ] Weights loaded via `Persistence.restore` into the constructed OCANNL model graph
+- [ ] Tokenization uses `Dataprep.Bpe.from_pretrained "openai-community/gpt2"` for encode/decode
+- [ ] Autoregressive generation loop: forward pass, sample from last-position logits, temperature scaling, greedy and top-k sampling modes
+- [ ] Forward-pass logits on a fixed test prompt match HuggingFace GPT-2 reference output within float32 tolerance (~1e-4 relative error per logit)
+- [ ] Generated text from "The quick brown fox" is coherent, recognizable English
+- [ ] Example runs on CPU (C backend) and completes generation of 50 tokens in < 60 seconds
+- [ ] Inference script at `test/training/gpt2_inference.ml` with `.expected` file for CI regression testing
+- [ ] Token embedding weight tying: input embedding matrix reused as output projection (logits = hidden @ embedding^T)
+
+## Context
+
+### Available infrastructure
+
+**Tensor persistence** (`lib/persistence.ml`): Fully implemented `save`, `load`, and `restore` with binary checkpoint format. `restore` matches by tnode ID and overwrites hosted buffers, verifying precision and dimension compatibility. This is the weight-loading mechanism.
+
+**Transformer blocks** (`lib/nn_blocks.ml`):
+- `multi_head_attention` (line 181): Separate Q/K/V projections via `w_q`, `w_k`, `w_v` params, scaled dot-product, optional causal mask, temperature, dropout, RoPE support
+- `layer_norm` (line 211): Learnable gamma/beta, configurable epsilon
+- `softmax` (line 107): Numerically stable with temperature, axis-specified via `~spec`
+- `mlp` (line 89): Variable-depth MLP with linear output, uses ReLU
+- `transformer_encoder_block` (line 220): Post-norm self-attention + FFN (close but uses post-norm and ReLU; no mask parameter)
+- `dropout` (line 82): Controlled by train_step presence
+
+**Decoder-only pattern** already demonstrated in `test/training/fsm_transformer.ml`: A decoder-only model with masked self-attention, learned positional embeddings, causal mask, separate training and inference compilation, and shared weight parameters between the two. This is the primary reference for how to structure the GPT-2 inference script.
+
+**BPE tokenizer** (`Dataprep.Bpe` in `ocaml-dataprep`): Fully implemented, supports HuggingFace `tokenizer.json` format. API: `from_pretrained "openai-community/gpt2"` for download+load, `encode t string -> int array`, `decode t ids -> string`, `vocab_size t -> int`. Compatible with GPT-2's byte-level BPE (50257 vocab).
+
+**One-hot encoding** (`nn_blocks.ml` line 61): `one_hot_of_int_list ~num_classes` converts integer indices to one-hot tensors. Usable for embedding lookup at inference time (single token at a time: 50257 floats = ~200KB, feasible).
+
+**Activations available**: ReLU, Exp, Log, Sin, Cos, Sqrt, Neg, Tanh, Sat01, Recip, Recip_sqrt. No GeLU or SiLU.
+
+### GPT-2 Small architecture
+
+| Parameter | Value |
+|-----------|-------|
+| vocab_size | 50257 |
+| n_positions | 1024 |
+| n_embd (d_model) | 768 |
+| n_layer | 12 |
+| n_head | 12 |
+| d_k = d_v | 64 (768/12) |
+| d_ff | 3072 (4 * 768) |
+| activation | GeLU (tanh approx) |
+| normalization | Pre-layer-norm |
+| positional | Learned absolute embeddings |
+| output projection | Tied to token embedding |
+| total params | ~124M (~500MB fp32) |
+
+### Key technical challenges
+
+1. **Embedding lookup**: With vocab_size=50257, full-sequence one-hot encoding is memory-prohibitive. For autoregressive inference (one token at a time), single-token one-hot is feasible (~200KB). For the initial prompt, process tokens sequentially or in a small batch. This avoids the need for #343 (dynamic indexing).
+
+2. **Pre-layer-norm block**: The existing `transformer_encoder_block` uses post-norm. GPT-2 needs: `x = x + mha(ln1(x))` then `x = x + gelu_ffn(ln2(x))`. A new `decoder_only_block` must be added.
+
+3. **Fused QKV weight splitting**: HuggingFace GPT-2 stores `c_attn.weight` as a single (768, 2304) Conv1D-style matrix. The Python converter must: (a) transpose from (in, out) to (out, in), and (b) split into three (768, 768) matrices for separate `w_q`, `w_k`, `w_v`.
+
+4. **Weight ID mapping**: OCANNL identifies tensors by integer ID, not name. The workflow is: (1) construct the OCANNL model graph (assigns tnode IDs deterministically), (2) export a mapping of (label -> ID) from the OCaml side, (3) the Python converter writes the checkpoint using those IDs.
+
+5. **Token embedding tying**: GPT-2 ties input embeddings and output projection. In OCANNL, the model construction must reference the same weight param for both `w_embed * one_hot_input` and `w_embed * hidden` (logits).
+
+6. **No KV cache**: Initial implementation recomputes the full attention over the entire sequence at each generation step. This is O(n^2) per step but correct. KV caching is a follow-up optimization.
+
+### Dependencies
+
+- **Tensor persistence (#373)**: DONE -- `Persistence.{save,load,restore}` fully implemented
+- **BPE tokenizer**: DONE -- `Dataprep.Bpe` supports GPT-2 via `from_pretrained`
+- **RoPE (#398)**: Not needed for GPT-2 (uses learned positional embeddings)
+- **#343 (dynamic indexing)**: Not needed -- single-token one-hot is sufficient for inference
+
+## Approach
+
+### Phase 1: nn_blocks.ml additions (GeLU + decoder-only blocks)
+
+**Add GeLU activation** as a composable function:
+```ocaml
+let gelu x =
+  let%op result =
+    x *. !.0.5 *. (!.1.0 + tanh (sqrt !.(2.0 /. Float.pi) *. (x + !.0.044715 *. (x *. x *. x))))
+  in result
+```
+This uses the standard tanh approximation and composes entirely from existing operations (pointmul, add, tanh, sqrt, pointpow).
+
+**Add `decoder_only_block`**: Pre-layer-norm masked self-attention + FFN with configurable activation:
+```ocaml
+let decoder_only_block ~label ~num_heads ~d_k ~d_v ~d_ff
+    ?(epsilon = 1e-5) ?(activation = relu) ?(pos_embed = No_pos_embed) () =
+  let mha = multi_head_attention ~label:("mha" :: label)
+    ~num_heads ~d_k ~d_v ~pos_embed () in
+  let ln1 = layer_norm ~label:("ln1" :: label) ~epsilon () in
+  let ln2 = layer_norm ~label:("ln2" :: label) ~epsilon () in
+  fun ~train_step ~mask x ->
+    let x = x + mha ~train_step ~mask (ln1 x) in
+    x + (fun h -> { w2 } * activation ({ w1; o = [d_ff] } * h + { b1 = 0. })) (ln2 x) + { b2 = 0. }
+```
+This mirrors the `fsm_transformer.ml` pattern but with pre-norm and configurable activation.
+
+**Add `decoder_only_transformer`**: Stacks N blocks with a final layer norm:
+```ocaml
+let decoder_only_transformer ~label ~num_layers ~num_heads ~d_k ~d_v ~d_ff
+    ?(epsilon = 1e-5) ?(activation = relu) ?(pos_embed = No_pos_embed) () =
+  let layers = List.init num_layers ~f:(fun i ->
+    decoder_only_block ~label:(("layer" ^ Int.to_string i) :: label)
+      ~num_heads ~d_k ~d_v ~d_ff ~epsilon ~activation ~pos_embed ()) in
+  let ln_f = layer_norm ~label:("ln_f" :: label) ~epsilon () in
+  fun ~train_step ~mask x ->
+    let h = List.fold layers ~init:x ~f:(fun x layer -> layer ~train_step ~mask x) in
+    ln_f h
+```
+
+### Phase 2: Weight conversion script
+
+Python script `scripts/convert_gpt2_weights.py`:
+1. Download GPT-2 Small from HuggingFace using `transformers` library
+2. Extract state dict, iterate over parameter names
+3. For each `h.{i}.attn.c_attn.weight`: transpose (768,2304) -> (2304,768), split into Q/K/V (768,768) each
+4. For each `h.{i}.attn.c_attn.bias`: split into Q/K/V (768,) each
+5. For each `h.{i}.mlp.c_fc.weight` and `c_proj.weight`: transpose Conv1D style (in,out) -> (out,in)
+6. Write OCANNL checkpoint format:
+   - Build s-expression header with tensor metadata (ID, label, prec=Single, dims, offset, byte_length)
+   - Write binary float32 data contiguously
+7. The script accepts a `--id-mapping` JSON file that maps OCANNL tensor labels to integer IDs
+
+The ID mapping is generated by a small OCaml helper that constructs the GPT-2 model graph and prints the label-to-ID mapping for all parameters.
+
+### Phase 3: Inference script (`test/training/gpt2_inference.ml`)
+
+Structure follows the `fsm_transformer.ml` pattern:
+
+1. **Construct model graph**: Build GPT-2 architecture using the new `decoder_only_transformer` block, with `gelu` activation, d_model=768, 12 layers, 12 heads
+2. **Load weights**: Use `Persistence.restore` to fill in pre-trained weights from the converted checkpoint file
+3. **Tokenize input**: Use `Dataprep.Bpe.from_pretrained "openai-community/gpt2"` to encode the prompt
+4. **Embedding**: Convert token IDs to one-hot vectors, multiply by embedding matrix
+5. **Add positional encoding**: Add learned positional embeddings (loaded from checkpoint)
+6. **Forward pass**: Run through all 12 transformer blocks with causal mask
+7. **Output projection**: Multiply final hidden state by embedding matrix transpose (weight tying)
+8. **Sampling**: Extract logits for last position, apply temperature, optionally top-k filter, sample from softmax
+9. **Generation loop**: Append sampled token, re-run forward pass on growing sequence
+
+The `.expected` file will test greedy decoding with a fixed prompt to ensure deterministic output for CI.
+
+### Phase 4: Validation
+
+1. **Logit comparison**: Python script that runs the same prompt through HuggingFace GPT-2 and dumps logits. The OCaml test compares against these reference logits.
+2. **Greedy generation match**: Verify that greedy decoding (temperature=0) produces the same token sequence as the HuggingFace reference for a short prompt.
+3. **Qualitative check**: Generated text from open prompts is coherent English.
+
+### File layout
+
+```
+lib/nn_blocks.ml              -- add gelu, decoder_only_block, decoder_only_transformer
+scripts/convert_gpt2_weights.py  -- weight conversion from HuggingFace to OCANNL checkpoint
+scripts/dump_gpt2_reference.py   -- dump reference logits for validation
+test/training/gpt2_inference.ml  -- main inference example
+test/training/gpt2_inference.expected  -- CI regression output
+```
+
+### Estimated effort
+
+Large (7-10 days):
+- Days 1-2: GeLU activation, `decoder_only_block`, `decoder_only_transformer` in nn_blocks.ml. Unit tests.
+- Day 3: Python weight conversion script. ID mapping helper.
+- Day 4: Weight loading integration -- construct model, restore weights, verify shapes match.
+- Day 5: Tokenizer integration -- encode prompt, decode output, handle special tokens.
+- Days 6-7: Autoregressive generation loop -- forward pass, sampling, text output.
+- Days 8-9: Validation against HuggingFace reference. Debug numerical differences.
+- Day 10: CI test, documentation, cleanup.

--- a/docs/proposals/gh-ocannl-382.md
+++ b/docs/proposals/gh-ocannl-382.md
@@ -1,0 +1,64 @@
+# Proposal: Remove remaining unnecessary zeroing-out in backend code
+
+**Issue**: https://github.com/ahrefs/ocannl/issues/382
+
+## Goal
+
+Eliminate redundant zeroing in generated C code. Currently, local arrays that need zero-initialization get zeroed twice: once via the C declaration initializer (`= {0}`) and again via an explicit loop generated from the `Zero_out` IR node. Only one mechanism should fire for any given array, and in cases where the accumulation projection is bijective (surjective + injective), no zeroing should be emitted at all.
+
+## Acceptance Criteria
+
+- No generated C code has both a `= {0}` declaration initializer AND an explicit zeroing loop for the same array.
+- When accumulation projection is both surjective and injective, no zeroing is emitted (no `= {0}`, no loop).
+- No regression in existing tests -- zeroing still occurs when genuinely needed (partial writes, re-zeroing between iterations, non-bijective projections).
+- Generated code from examples (e.g., introductory slides matmul) is visibly cleaner.
+
+## Context
+
+### Root Cause
+
+The dual-zeroing arises from two independent mechanisms triggered by the same `Zero_out` IR node:
+
+1. **Tracing** (`low_level.ml:289-296`): When `Zero_out tn` is traced and the array has no prior assignments or accesses, `zero_initialized_by_code` is set to `true`. This causes the C declaration to include `= {0}` (`c_syntax.ml:872`).
+
+2. **Code generation** (`c_syntax.ml:332-335`): `Zero_out tn` is unconditionally expanded into an explicit `loop_over_dims` that sets every element to `(float)(0)`.
+
+Both mechanisms fire for the same array, producing the redundant code shown in the issue.
+
+### Key Code Paths
+
+- `assignments.ml:417-424` -- `needs_init` check: already correctly skips zeroing when projection is surjective AND injective. This is not the problem site.
+- `assignments.ml:718-719` -- `Fetch { fetch_op = Constant 0.0 }` becomes `Zero_out`.
+- `low_level.ml:289-296` -- Tracing sets `zero_initialized_by_code` on first-touch `Zero_out`.
+- `c_syntax.ml:332-335` -- Code gen expands `Zero_out` into explicit zeroing loop.
+- `c_syntax.ml:871-873` -- Declaration emits `= {0}` when `zero_initialized_by_code` is true.
+- `backends.ml:485-487` -- Device allocation uses `alloc_array` (skipping `alloc_zeros`) when `zero_initialized_by_code` is true.
+
+### The Three Zeroing Levels
+
+| Level | Mechanism | When needed |
+|-------|-----------|-------------|
+| Declaration `= {0}` | C local array init | First-touch zeroing of stack-allocated arrays |
+| Explicit loop | `Zero_out` IR expansion | Re-zeroing between iterations (not first touch) |
+| `alloc_zeros` | Device buffer allocation | Device buffers without `zero_initialized_by_code` |
+
+The fix must distinguish first-touch zeroing (declaration suffices) from re-zeroing (loop required).
+
+### Approach
+
+**In `c_syntax.ml` code generation for `Zero_out`**: The `traced_store` is already available in the compilation context (it is part of the `optimized` record passed to the compilation function). When generating code for `Zero_out tn`:
+
+- Look up `tn` in `traced_store`.
+- If `zero_initialized_by_code` is true for that node, emit `Noop` instead of the zeroing loop -- the declaration `= {0}` already handles it.
+- Otherwise (re-zeroing, or array not declaration-zeroed), emit the loop as before.
+
+This is the minimal, safe fix. The `zero_initialized_by_code` flag is only set when `Zero_out` is the first operation on the array (no prior assignments or accesses), which exactly matches the condition where declaration initialization suffices.
+
+**Verification**: The `needs_init` logic (`assignments.ml:422-424`) already prevents `Zero_out` from being emitted when projection is bijective. The dual-zeroing only occurs for arrays that genuinely need initialization but get it twice. No change to `needs_init` or `initialize_neutral` is required.
+
+### Edge Cases
+
+- **Re-zeroing between iterations**: When `Zero_out` fires on an array that already has prior assignments, `zero_initialized_by_code` remains `false` (the tracing condition at `low_level.ml:291` checks `Hash_set.is_empty traced.assignments`). The explicit loop is correctly preserved.
+- **Device buffers**: Unaffected -- they use `alloc_zeros` / `alloc_array` path in `backends.ml`, not the C declaration mechanism.
+- **Merge buffers**: Follow the same tracing logic; the fix applies uniformly.
+- **Relation to #340**: That issue concerns scalar `Local_scope` variables (`c_syntax.ml:514-528`), which is a separate code path.

--- a/docs/proposals/gh-ocannl-383.md
+++ b/docs/proposals/gh-ocannl-383.md
@@ -1,0 +1,76 @@
+# Proposal: Blacklist primitive operator names when selecting identifier names
+
+**Task**: gh-ocannl-383
+**Issue**: https://github.com/ahrefs/ocannl/issues/383
+
+## Goal
+
+Ensure generated C code never uses C math function names or C keywords as variable
+identifiers, and update the introductory slides to reflect current identifier naming.
+
+The core blacklist infrastructure already exists (commit 132144b1, May 2025). This
+task completes the work by extending coverage to C keywords and verifying slides.
+
+## Acceptance Criteria
+
+- C math function names (exp, log, sqrt, fma, fmaf, fmaxf, fminf, copysignf, etc.)
+  remain blacklisted via the dynamic extraction in `c_syntax.ml` `ident_blacklist`.
+- C language keywords (int, float, for, if, return, etc.) and C99 additions are added
+  to the blacklist so that tensor labels matching these names get disambiguated.
+- The `ident_blacklist` in `c_syntax.ml` is the single source of truth; no other
+  `get_ident_within_code` call sites need modification (the `assignments.ml` and
+  `low_level.ml` pretty-printers produce OCaml-level IR, not C code).
+- The introductory slides (`docs/slides-basics_backprop_training_codegen.md`) are
+  reviewed and updated if any generated code examples show pre-blacklist naming.
+- Existing tests pass without regression.
+
+## Context
+
+### Current implementation
+
+1. **`ident_blacklist`** (`arrayjit/lib/c_syntax.ml` lines 107-172): Dynamically
+   extracts C math function names by probing `Ops.unop_c_syntax`, `binop_c_syntax`,
+   `ternop_c_syntax`, and `vec_unop_c_syntax` across all precisions. Any result
+   ending with `(` is treated as a function call and the name is collected.
+
+2. **Blacklist consumption** (`c_syntax.ml` line 233): Passed to
+   `Low_level.get_ident_within_code ~blacklist:B.ident_blacklist`.
+
+3. **Disambiguation** (`tnode.ml` `styled_ident`, lines 536-558): When a label
+   appears in the `repeating_*_idents` hash tables (which include blacklisted names
+   seeded with a sentinel ID of -1), the identifier is prefixed with `n<id>_`.
+
+### Gap: no C keyword coverage
+
+The dynamic extraction only captures math function names. C keywords like `int`,
+`float`, `for`, `if`, `return` are not blacklisted. While unlikely as tensor labels,
+PPX-derived labels come from OCaml variable names, and some overlap exists (e.g.
+`for`, `if`, `mod`). Adding a static keyword list closes this gap.
+
+### Slides status
+
+The slides at `docs/slides-basics_backprop_training_codegen.md` already use
+disambiguated variable names (e.g., `n35`, `w3_grad`) and C function names appear
+only as function calls (`fma(`, `fmaf(`, `fmaxf(`). No pre-blacklist naming issues
+are visible, but the slides should be verified against current codegen output after
+the keyword extension.
+
+### Approach
+
+1. Add a `c_keywords` list in `c_syntax.ml` containing C89/C99 reserved words and
+   append it to the dynamically extracted `ident_blacklist`.
+2. Optionally add CUDA/Metal reserved words behind a comment or gated on backend,
+   for future-proofing.
+3. Regenerate or manually verify slide code examples against current output.
+4. Run the full test suite to confirm no regressions.
+
+### Code pointers
+
+| Location | Role |
+|----------|------|
+| `arrayjit/lib/c_syntax.ml:107-172` | `ident_blacklist` definition |
+| `arrayjit/lib/c_syntax.ml:233` | Blacklist passed to `get_ident_within_code` |
+| `arrayjit/lib/low_level.ml:1425-1470` | `get_ident_within_code` with blacklist seeding |
+| `arrayjit/lib/tnode.ml:536-558` | `styled_ident` disambiguation logic |
+| `arrayjit/lib/tnode.ml:523-534` | `no_grad_ident_label` label extraction |
+| `docs/slides-basics_backprop_training_codegen.md` | Introductory slides |

--- a/docs/proposals/gh-ocannl-409.md
+++ b/docs/proposals/gh-ocannl-409.md
@@ -1,0 +1,74 @@
+# Proposal: Relax `ocannl_` prefix for commandline arguments and validate config keys
+
+**Issue**: https://github.com/ahrefs/ocannl/issues/409
+**Task**: gh-ocannl-409
+
+## Goal
+
+Improve OCANNL configuration usability by (1) accepting commandline arguments without the `ocannl_` prefix, (2) validating config file keys and commandline args against a known set, and (3) fixing discrepancies between `ocannl_config.example` and actual code usage.
+
+## Acceptance Criteria
+
+- Commandline arguments work without the `ocannl_` prefix (e.g., `--backend=multicore_cc`)
+- Commandline arguments still work WITH the `ocannl_` prefix for backward compatibility
+- Unknown config file keys produce a warning at load time
+- Commandline arguments matching `--ocannl_*` that don't correspond to any known key produce a warning
+- `ocannl_config.example` is a superset of all `get_global_arg`/`get_global_flag` call sites -- verified by a build-time or test-time check
+- All discrepancies in `ocannl_config.example` and `ocannl_config.for_debug` are fixed
+- No regression in existing tests
+- Environment variables retain the `OCANNL_` prefix (to avoid namespace collisions)
+
+## Context
+
+### Current state
+
+Configuration resolution in `arrayjit/lib/utils.ml`:
+
+1. **Commandline** (`read_cmdline_or_env_var`, lines 53-79): generates 12 variants per key, all requiring the `ocannl_` prefix. Scans `Sys.argv` for prefix matches.
+2. **Environment variables**: checks `ocannl_<name>` and `OCANNL_<NAME>` variants.
+3. **Config file** (`config_file_args`, lines 97-158): walks directory tree for `ocannl_config`, already strips the `ocannl` prefix from keys.
+4. **Defaults**: hard-coded at each `get_global_arg`/`get_global_flag` call site.
+
+The config file parser already accepts keys without the prefix. Only the commandline parser requires it.
+
+### Known discrepancies (as of current HEAD)
+
+| File | Issue |
+|------|-------|
+| `ocannl_config.example` line 69 | `bacend=multicore_cc` -- typo, should be `backend` |
+| `ocannl_config.example` line 136 | `randomness_lib=stdlib` -- no corresponding `get_global_arg` call in code |
+| `ocannl_config.example` | Missing: `default_prng_variant`, `cd_ident_style`, `never_capture_stdout` (partially -- it's at line 77 but the key used in code is `never_capture_stdout`) |
+| `ocannl_config.for_debug` line 11 | `output_debug_files_in_run_directory=true` -- stale name, should be `output_debug_files_in_build_directory` |
+| `ocannl_config.for_debug` line 14 | `randomness_lib=for_tests` -- unused key |
+
+### All known config keys from code
+
+Extracted from all `get_global_arg`/`get_global_flag` call sites (54 unique keys):
+
+**Settings (utils.ml)**: `log_level`, `debug_log_from_routines`, `output_debug_files_in_build_directory`, `fixed_state_for_init`, `print_decimals_precision`, `check_half_prec_constants_cutoff`, `automatic_host_transfers`, `default_prng_variant`, `big_models`
+
+**Cleanup/bootstrap (utils.ml)**: `suppress_welcome_message`, `no_config_file`, `clean_up_log_files_on_startup`, `clean_up_build_files_on_startup`, `never_capture_stdout`
+
+**ppx_minidebug (utils.ml)**: `snapshot_every_sec`, `time_tagged`, `elapsed_times`, `location_format`, `debug_backend`, `hyperlink_prefix`, `logs_print_scope_ids`, `logs_verbose_scope_ids`, `log_main_domain_to_stdout`, `log_file_stem`, `toc_entry_minimal_depth`, `toc_entry_minimal_size`, `toc_entry_minimal_span`, `debug_highlights`, `debug_highlight_pcre`, `prev_run_prefix`, `diff_ignore_pattern_pcre`, `diff_max_distance_factor`, `debug_scope_id_pairs`, `debug_log_truncate_children`, `debug_log_prune_upto`, `debug_log_to_stream_files`
+
+**Backends**: `backend`, `prefer_backend_uniformity`, `cc_backend_optimization_level`, `cc_backend_compiler_command`, `cc_backend_arch_flags`, `cc_backend_fast_math`, `cc_backend_post_compile_timeout`, `cc_backend_verify_codesign`, `output_dlls_in_build_directory`, `cuda_printf_fifo_size`
+
+**Low-level/optimization**: `virtualize_max_visits`, `virtualize_max_tracing_dim`, `enable_device_only`, `inline_scalar_constexprs`, `inline_simple_computations`, `inline_complex_computations`, `output_prec_in_ll_files`, `stack_threshold_in_bytes`
+
+**Other**: `ll_ident_style`, `cd_ident_style`, `default_prec`, `limit_constant_fill_size`, `max_shape_error_origins`
+
+### Approach
+
+1. **Add prefix-free commandline variants** in `read_cmdline_or_env_var`: generate additional variants without the `ocannl_` prefix (e.g., `--backend=`, `-backend=`, `backend=`). Keep all existing prefixed variants for backward compatibility.
+
+2. **Build a known-keys registry** as a static `Set` in `utils.ml` listing all valid config key names. This is explicit and gives immediate validation at runtime.
+
+3. **Validate config file keys** at load time: after parsing `ocannl_config`, warn on any key not in the known set.
+
+4. **Validate commandline args** at initialization: scan `Sys.argv` for entries matching `--ocannl_*` or `--ocannl-*` patterns that don't match any known key, and warn.
+
+5. **Fix all discrepancies** in `ocannl_config.example` and `ocannl_config.for_debug` (see table above). Add missing keys (`default_prng_variant`, `cd_ident_style`) to the example file.
+
+6. **Add a consistency test** that extracts `arg_name` strings from `get_global_arg`/`get_global_flag` call sites and verifies they all appear in `ocannl_config.example`, and vice versa (bidirectional check).
+
+7. **Rename consideration**: The issue suggests renaming `ocannl_config.example`. Since the actual config file name `ocannl_config` is searched for by that exact name in the directory walk, only the example/reference file could be renamed. A reasonable choice is `ocannl_config.reference` to clarify it is the canonical documentation of all keys. This is a minor point and can be decided during implementation.

--- a/docs/proposals/gh-ocannl-412.md
+++ b/docs/proposals/gh-ocannl-412.md
@@ -1,0 +1,208 @@
+# Proposal: Tiling and Multi-Threaded GPU Kernels (Matrix Multiplication Optimizations)
+
+**Task**: gh-ocannl-412
+**Issue**: https://github.com/ahrefs/ocannl/issues/412
+
+## Goal
+
+Transform OCANNL from single-threaded GPU kernels into properly parallelized, tiled execution across CUDA, Metal, and C backends. This is the core of the v0.8 milestone ("GPU-style performance"). The work introduces loop tiling as an IR transformation, maps tiled loops to GPU thread/block indices for parallel execution, and adds shared memory (SMEM) cooperation and register blocktiling for memory hierarchy exploitation. The end state is that matrix multiplication (and general einsum operations with contraction dimensions) achieves substantial speedups by utilizing GPU parallelism and memory hierarchy -- moving from the current baseline of `grid_dim=1, block_dim=1` to properly configured multi-threaded kernels.
+
+## Acceptance Criteria
+
+- [ ] A loop tiling IR pass exists in `low_level.ml` that can split `For_loop` nodes into outer (tile) + inner (element) loop pairs, parameterized by tile size
+- [ ] CUDA kernels launch with non-trivial `grid_dim` and `block_dim` computed from tiling parameters and tensor dimensions (the `kernel_prep_line` single-thread guard is removed or conditioned)
+- [ ] For parallelizable (non-contracted) dimensions, outer tile loops are mapped to `blockIdx` and inner elements to `threadIdx`, with correct index arithmetic in the generated code
+- [ ] CUDA code generation can emit `__shared__` memory declarations and `__syncthreads()` barriers for cooperative tile loading
+- [ ] Register blocktiling: each GPU thread computes a small TM x TN tile of the output, accumulating in register-allocated arrays, with inner loops reading from shared memory
+- [ ] C backend emits tiled loops with configurable tile sizes for cache-friendly execution of contraction operations
+- [ ] Matrix multiplication performance improves measurably vs the single-threaded baseline (target: >10x for matrices of size >= 256x256)
+- [ ] Small tensors (below a configurable threshold) continue to use the current single-threaded path, avoiding tiling overhead
+- [ ] No regression in existing tests (the tiling pass is opt-in or automatically bypassed for small/non-tileable operations)
+- [ ] The tiling parameters (BM, BN, BK, TM, TN) are configurable via `Utils.settings` or a dedicated tiling config, with sensible defaults
+
+## Context
+
+### Current Architecture
+
+**The single-threaded baseline.** All CUDA kernels currently run with a single thread:
+- `cuda_backend.ml` line 328-329: `kernel_prep_line = "/* FIXME: single-threaded for now. */if (threadIdx.x != 0 || blockIdx.x != 0) { return; }"`
+- `cuda_backend.ml` line 979: `S.launch_kernel func ~grid_dim_x:1 ~block_dim_x:1 ~shared_mem_bytes:0 stream.runner args`
+- `metal_backend.ml` lines 787-794: dispatches with `threadgroups_per_grid: {1,1,1}` and `width = min max_threads 1`
+
+**The IR-to-code pipeline.** Operations flow through:
+1. **Shape system** (`shape.ml`): einsum specs with batch/output/input dimensions. "Input" dims are the contracted (reduction) dimensions in an einsum; "batch" and "output" are non-contracted.
+2. **Projections** (`indexing.ml` lines 136-157): `projections.product_space` and `product_iterators` define the iteration space. `project_lhs` and `project_rhs` map product iterators to tensor indices.
+3. **Assignments** (`assignments.ml`): `Accum_op` with accumulator (`accum: Ops.binop`), LHS, RHS, and projections. `to_low_level` (line 190) converts to nested `For_loop` nodes by iterating over `product_space` dimensions.
+4. **Low-level IR** (`low_level.ml`): `For_loop { index; from_; to_; body }` nodes, `Set`/`Get`/`Local_scope` for scalar computation. `optimize_proc` (line 1388) runs virtualization, simplification, and CSE.
+5. **C syntax emission** (`c_syntax.ml`): `pp_ll` (line 305) converts `For_loop` to C `for` loops. `compile_proc` (line 756) assembles the full kernel function.
+6. **Backend launch** (`cuda_backend.ml`): NVRTC compilation, module loading, kernel launch.
+
+**Key observation for tiling.** The `product_space` in projections already separates the iteration dimensions. In a matrix multiply `C[i,j] += A[i,k] * B[k,j]`:
+- Batch dims: none (or outer batch axes)
+- Output dims: `i`, `j` (appear in `project_lhs`, do NOT reduce)
+- Input (contracted) dims: `k` (appears in `project_rhs` for both A and B, reduces via accumulation)
+
+The tiling strategy maps directly:
+- Output dims (`i`, `j`) -> tiled and parallelized across `blockIdx` / `threadIdx`
+- Contracted dims (`k`) -> tiled sequentially within each thread, with cooperative SMEM loading
+
+### Key Code Pointers
+
+| Location | Description |
+|----------|-------------|
+| `arrayjit/lib/low_level.ml` lines 33-50 | IR type definition: `For_loop`, `Set`, `Get`, `Local_scope` |
+| `arrayjit/lib/low_level.ml` lines 1695-1711 | `loop_over_dims` -- generates nested for-loops from dimension array |
+| `arrayjit/lib/low_level.ml` lines 1713-1741 | `unroll_dims` -- full unrolling for small dimensions |
+| `arrayjit/lib/low_level.ml` lines 1388-1398 | `optimize_proc` -- the optimization pipeline entry point |
+| `arrayjit/lib/low_level.ml` lines 168-174 | `optimized` record type (traced_store, llc, merge_node) |
+| `arrayjit/lib/assignments.ml` lines 282-451 | `loop_accum` -- lowers `Accum_op` to `For_loop` nests with projection-based indexing |
+| `arrayjit/lib/indexing.ml` lines 136-157 | `projections` type with `product_space`, `product_iterators`, `project_lhs`, `project_rhs` |
+| `arrayjit/lib/c_syntax.ml` lines 16-75 | `C_syntax_config` module type -- backend-specific hooks |
+| `arrayjit/lib/c_syntax.ml` lines 305-331 | `pp_ll` -- For_loop to C for-loop emission |
+| `arrayjit/lib/c_syntax.ml` lines 756-810 | `compile_proc` -- kernel function assembly, `kernel_prep_line` emission |
+| `arrayjit/lib/cuda_backend.ml` lines 312-390 | `Cuda_syntax_config` -- CUDA-specific types, builtins |
+| `arrayjit/lib/cuda_backend.ml` line 979 | Kernel launch with hardcoded `grid_dim_x:1, block_dim_x:1` |
+| `arrayjit/lib/builtins_cuda.ml` | CUDA builtins: vector types (`float4_t`, `half8_t`), FMA, conversions |
+| `arrayjit/lib/metal_backend.ml` lines 787-794 | Metal dispatch with 1 threadgroup |
+| `ROADMAP.md` lines 118-135 | v0.8 milestone definition |
+
+### Related Work
+
+- **gh-ocannl-351** (CSE after inlining): Should ideally run before tiling to simplify the IR. Soft dependency -- tiling can proceed independently.
+- **gh-ocannl-350** (Loop invariant hoisting): Same soft dependency as CSE.
+- **gh-ocannl-318** (Megakernels): Complementary -- megakernels fuse multiple operations; tiling optimizes within a single operation. Both are v0.8 targets.
+- **gh-ocannl-411** (HIP backend): HIP tiling follows the same patterns as CUDA tiling.
+- **gh-ocannl-311** (Add `-march=native`): CPU performance floor for the C backend.
+
+### Reference Articles
+
+The optimization techniques are well-documented in the articles collected in issue #412:
+- [Böhm: Fast CPU MMM](https://siboehm.com/articles/22/Fast-MMM-on-CPU) -- tiling, register blocking, cache hierarchy for CPU
+- [Böhm: CUDA MMM](https://siboehm.com/articles/22/CUDA-MMM) -- global memory coalescing, SMEM tiling, 2D register blocktiling, vectorized loads, warptiling
+- [Seb-v: Fast GPU MatMul](https://seb-v.github.io/optimization/update/2025/01/20/Fast-GPU-Matrix-multiplication.html) -- CUDA optimization walkthrough
+- [ArmbR: Tensor Cores from Scratch](https://alexarmbr.github.io/2024/08/10/How-To-Write-A-Fast-Matrix-Multiplication-From-Scratch-With-Tensor-Cores.html) -- WMMA/MMA intrinsics
+- [CUDAForFun: Outperforming cuBLAS on H100](https://cudaforfun.substack.com/p/outperforming-cublas-on-h100-a-worklog) -- advanced tiling + tensor cores
+- [gau-nernst: Blackwell tcgen05](https://gau-nernst.github.io/tcgen05/) -- next-gen tensor core architecture
+
+## Approach
+
+The implementation is structured in five phases, each building on the previous and producing a testable, committable increment. Metal backend parallelism and tensor core support are deferred to follow-up work.
+
+### Phase 1: IR-Level Loop Tiling Transform
+
+**Goal:** Add a tiling pass to `low_level.ml` that structurally transforms `For_loop` nodes into tiled (outer + inner) loop pairs.
+
+**Changes:**
+- Add a new IR node variant or use existing `For_loop` with a tiling annotation. The simplest approach is to keep `For_loop` unchanged and have a separate `tile_loops` pass that rewrites the IR:
+  ```
+  For_loop { index=i; from_=0; to_=N-1; body }
+    -->
+  For_loop { index=tile_i; from_=0; to_=(N-1)/TILE; body =
+    For_loop { index=i; from_=tile_i*TILE; to_=min((tile_i+1)*TILE-1, N-1); body } }
+  ```
+- The inner loop index `i` becomes an `Affine { symbols = [(1, tile_i); (1, inner_i)]; offset = 0 }` or the body's index references are rewritten to use `tile_i * TILE + inner_i`.
+- Add tiling configuration to `Utils.settings` or a new `Tiling_config` module: `tile_sizes: (int * int * int)` for (BM, BN, BK), `register_tile: (int * int)` for (TM, TN), and `min_tile_threshold: int`.
+- The `tile_loops` pass receives tiling annotations from the caller (based on projections analysis) specifying which loops to tile and with what parameters.
+- Insert this pass into `optimize_proc` after existing simplification passes, or apply it in `assignments.ml` at `to_low_level` time when projection information is still available.
+
+**Integration point decision:** Apply tiling in `assignments.ml`'s `loop_accum` function (line 282) where projection information is directly available, rather than as a post-hoc pass on the IR. This avoids the need to reverse-engineer which loops correspond to output vs contracted dimensions. The `product_space` array and `product_iterators` already distinguish parallelizable from reduction dimensions. The tiled loop structure can be generated directly:
+- Outer tile loops for output dimensions -> will become block indices
+- Inner tile loops for output dimensions -> will become thread indices
+- Outer tile loop for contracted dimension -> sequential, drives SMEM tile loading
+- Inner contracted loop -> sequential within each thread's register tile
+
+**Testability:** Generate tiled C code for the C backend, verify correctness against non-tiled version.
+
+### Phase 2: Multi-Threaded CUDA Kernels
+
+**Goal:** Remove the single-thread guard and launch CUDA kernels with proper grid/block dimensions.
+
+**Changes:**
+- Modify `kernel_prep_line` in `Cuda_syntax_config` to be empty (or conditional on a per-kernel flag).
+- Add a `Parallel_loop` variant to the IR (or annotate `For_loop` with a `parallel: parallel_kind option` field where `parallel_kind = Block_x | Block_y | Thread_x | Thread_y`). The code generator in `c_syntax.ml` maps these to:
+  - `Block_x` -> loop variable replaced by `blockIdx.x`, no for-loop emitted
+  - `Thread_x` -> loop variable replaced by `threadIdx.x`, no for-loop emitted
+  - Sequential (no annotation) -> normal for-loop
+- Compute `grid_dim_x`, `grid_dim_y`, `block_dim_x`, `block_dim_y` from the tiling parameters and pass them to `S.launch_kernel`. This requires extending the `code` record in `cuda_backend.ml` (or the `optimized` record) to carry launch configuration.
+- The `launch_kernel` call in `cuda_backend.ml` line 979 changes from hardcoded `1, 1, 0` to values derived from tiling parameters.
+- Element-wise operations (no contraction, all output dims) get a simple parallelization: one thread per output element (or a 1D tiled scheme).
+- Operations with contraction dimensions get the full tiled scheme from Phase 1.
+- **Fallback:** Operations below the `min_tile_threshold` use `grid_dim_x:1, block_dim_x:1` with the original single-threaded guard.
+
+**Key concern:** The existing `pp_ll` in `c_syntax.ml` emits the same code for all backends. Parallel loop annotations need to emit different code for CUDA vs C. Options:
+1. Add a `parallel_for_syntax` hook to `C_syntax_config` (preferred -- keeps the design modular).
+2. Check backend type inside `pp_ll` (breaks the clean parameterization).
+
+**Testability:** Launch simple element-wise operations with multiple threads, verify correctness. Launch tiled matmul kernels, verify correctness against CPU reference.
+
+### Phase 3: Shared Memory Tiling for CUDA
+
+**Goal:** Cooperative loading of input tiles into shared memory before computation.
+
+**Changes:**
+- Add IR constructs for shared memory:
+  - `Shared_decl of { name: string; prec: Ops.prec; size: int }` -- declare a `__shared__` array
+  - `Barrier` -- emit `__syncthreads()` (CUDA) / `threadgroup_barrier(...)` (Metal)
+  - `Cooperative_load of { shared: string; global_tn: Tn.t; ... }` -- each thread loads its portion
+  
+  Alternatively, handle SMEM as a code generation concern rather than an IR concern: the tiling pass in `assignments.ml` generates the cooperative load pattern using existing `For_loop` / `Set` / `Get` nodes, with SMEM arrays treated as special `Tnode.t` instances with a `Shared` memory mode (extending the existing `Local` mode). This is more aligned with OCANNL's existing architecture.
+
+- For a tiled matmul with tile size BM x BN x BK:
+  1. Each thread block loads a BM x BK tile of A and a BK x BN tile of B into SMEM
+  2. Threads cooperate on loading: each thread loads `(BM * BK) / (block_dim_x * block_dim_y)` elements
+  3. `__syncthreads()` after loading
+  4. Inner loop reads from SMEM instead of global memory
+  5. `__syncthreads()` before loading the next K-tile
+
+- Boundary handling: the last tile in each dimension may be smaller than the tile size. Guard global memory loads with bounds checks.
+
+**Testability:** Compare SMEM-tiled matmul output against CPU reference for various sizes including non-power-of-2.
+
+### Phase 4: Register Blocktiling
+
+**Goal:** Each thread computes a TM x TN tile of output, accumulating in registers.
+
+**Changes:**
+- Within the innermost K-loop iteration, each thread:
+  1. Loads TM elements from column of A's SMEM tile into a register array
+  2. Loads TN elements from row of B's SMEM tile into a register array
+  3. Computes the TM x TN outer product and accumulates in a TM x TN register array
+- After the K-loop completes, writes the TM x TN register tile back to global memory.
+
+- In the IR, this manifests as:
+  - The thread-level inner loops (over TM, TN) are fully unrolled (using `unroll_dims` or generated as flat sequences)
+  - Register arrays are `Local_scope` accumulators -- OCANNL already has this pattern
+  - The block dimension is `(BM/TM) * (BN/TN)` threads per block
+
+- Use FMA intrinsics (`fmaf` / `__fmaf_rn`) for the multiply-accumulate, leveraging existing builtins in `builtins_cuda.ml`.
+
+**Testability:** Measure FLOPS for tiled+register-blocked matmul vs Phase 3 (SMEM only) vs Phase 2 (parallel only) vs baseline.
+
+### Phase 5: C Backend Tiling and OpenMP
+
+**Goal:** Cache-friendly blocked loops for the CPU backend, optionally with OpenMP parallelism.
+
+**Changes:**
+- The tiling IR from Phase 1 is emitted as nested C for-loops (already happens naturally via `pp_ll`).
+- Tile sizes chosen to fit working sets in L1/L2 cache (BM = BN = BK = 64 or similar, tunable).
+- Optionally emit `#pragma omp parallel for` on outer tile loops. This requires a new `C_syntax_config` hook or a backend-specific annotation on outer loops.
+- The existing `-O3 -march=native` flags (from gh-ocannl-311) ensure the compiler auto-vectorizes the inner loops.
+
+**Testability:** Benchmark tiled CPU matmul against non-tiled baseline for various sizes.
+
+### Deferred (Follow-up Tasks)
+
+- **Metal backend parallelism** (Phase 6 in task elaboration): Map tiled loops to `threadgroup_position_in_grid` and `thread_position_in_threadgroup`. Use `threadgroup` memory for SMEM equivalent. This is straightforward once the IR supports parallel annotations from Phase 2.
+- **Tensor cores / WMMA** (Phase 7 in task elaboration): Requires detecting suitable matmul shapes, emitting `nvcuda::wmma` intrinsics, and SMEM swizzling. Significant additional complexity.
+- **Autotuning** (v0.9 scope): Compile multiple kernel variants with different tile sizes, benchmark, cache winners. OCANNL's runtime compilation is naturally suited for this.
+- **Vectorized memory access** (`float4` loads): Can be added after register blocktiling for additional throughput.
+- **Warptiling**: Explicit warp-level tiling hierarchy for further optimization.
+
+### Risk Mitigation
+
+- **Correctness of reductions**: Tiled reductions must correctly initialize accumulators and handle partial tiles. Use the existing `Local_scope` accumulator pattern for register tiles. Add assertion checks comparing tiled vs non-tiled results for a test suite of operation shapes.
+- **Small tensor regression**: Use a size threshold (configurable, default: total elements < 1024 or largest dim < 32) to fall back to the single-threaded path.
+- **Non-matmul operations**: Element-wise operations get simple parallelization (Phase 2) without SMEM tiling. Reductions without contraction dimensions get a parallel reduction pattern. Only operations with contraction dimensions (detected via projections) get the full SMEM + register tiling.
+- **SMEM limits**: Query `CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK` at device initialization. Tile sizes must respect `2 * BM * BK * sizeof(float)` plus `2 * BK * BN * sizeof(float)` <= SMEM limit. Clamp tile sizes if necessary.
+- **Register pressure**: Large TM * TN register tiles reduce GPU occupancy. Default TM = TN = 8 is a good balance. The v0.9 autotuner can search this space.
+- **Interaction with CSE/hoisting**: Tiling should be applied after virtualization/inlining but can precede or follow CSE. The tiling pass in `assignments.ml` runs before `optimize_proc`, so CSE will deduplicate within the tiled structure.

--- a/docs/proposals/gh-ocannl-420.md
+++ b/docs/proposals/gh-ocannl-420.md
@@ -1,0 +1,125 @@
+# Proposal: Optimize away zeroing-out before non-reducing accumulating assignment
+
+**Issue**: https://github.com/ahrefs/ocannl/issues/420
+
+## Goal
+
+Eliminate unnecessary `Zero_out` IR nodes for non-reducing accumulating assignments. Currently, operations using `=:+` (accumulating assignment with `initialize_neutral = true`) emit a `Zero_out` before the actual assignment even when the projection is bijective (surjective + injective), meaning every output element is written exactly once. This wastes one full memory pass. Additionally, when `Zero_out` IS legitimately emitted, the generated C code can double-zero: once via declaration `= {0}` and again via an explicit zeroing loop. Both issues should be fixed.
+
+## Acceptance Criteria
+
+- Non-reducing accumulating assignments with bijective projections do not emit `Zero_out` in the lowered IR.
+- The `top_down_prec.c.expected` test no longer has the redundant `d[0] = single_to_bfloat16((float)0);` line.
+- The `top_down_prec-unoptimized.ll.expected` test no longer has `zero_out d<bfloat16>;` (and `zero_out n6<half>;` is also removed if applicable).
+- Reducing accumulating assignments (genuine reductions where projection is not injective) continue to zero correctly.
+- Non-surjective cases (e.g., diagonal tensor `i=>ii`) continue to zero correctly.
+- When `Zero_out` is legitimately emitted AND the node has `zero_initialized_by_code = true`, the explicit zeroing loop in code generation is skipped (declaration `= {0}` suffices).
+- Update all affected `.expected` test files.
+- No regression in existing tests.
+
+## Context
+
+### Root Cause: `is_surjective` bug for trivial-dim projections
+
+The primary issue is a bug in `indexing.ml:is_surjective`. For scalar arrays (or arrays where all dimensions are 1), the projection uses `Fixed_idx 0` for each axis (since `opt_symbol` returns `None` when dim <= 1). The surjectivity check at line 241:
+
+```ocaml
+Set.length lhs_symbol_set >= Array.length proj.project_lhs
+```
+
+fails because `lhs_symbol_set` is empty (no symbols from `Fixed_idx` entries), while `project_lhs` has one or more axes. So `0 >= 1 = false`, and `is_surjective` incorrectly returns `false`.
+
+This causes `needs_init` at `assignments.ml:422-424` to be `true` even though the projection is trivially surjective (there is only one position per axis, and `Fixed_idx 0` covers it). The result is an unnecessary `Fetch { Constant 0.0 }` which lowers to `Zero_out`.
+
+**Concrete example**: In `top_down_prec.ml`, `%op d = ({ a = [ 2 ] } + { b = [ 2 ] }) *. { c = [ 2 ] }` generates a pointwise multiplication with `initialize_neutral = true`. All tensors are scalar. The projection is identity (`Fixed_idx 0` for each axis). The assignment at `assignments.ml:394` correctly uses `set` (not `+=`) via `can_skip_accumulation`. But `needs_init` is incorrectly `true`, so `Zero_out` is emitted.
+
+Note: `is_injective` does NOT have this bug -- for the scalar case, `product_iterator_sets = [[]]` (one empty combination), the empty set is a subset of the (empty) `lhs_symbol_set`, so `good` is non-empty and injectivity correctly returns `true`.
+
+### Secondary Issue: dual zeroing in code generation
+
+When `Zero_out` IS legitimately needed (e.g., non-surjective projections like diagonal tensors), two independent mechanisms fire:
+
+1. **Tracing** (`low_level.ml:289-296`): Sets `zero_initialized_by_code = true` for first-touch `Zero_out`, causing `= {0}` in the C declaration (`c_syntax.ml:872`).
+2. **Code generation** (`c_syntax.ml:332-335`): Unconditionally expands `Zero_out` to an explicit zeroing loop.
+
+Both fire for the same array when it's the first operation. This is tracked more broadly in issue #382 but should be addressed here for completeness.
+
+### Key Code Paths
+
+- `indexing.ml:164-241` -- `is_surjective`: the buggy check (line 241)
+- `indexing.ml:243-283` -- `is_injective`: correct for this case
+- `assignments.ml:422-424` -- `needs_init` check using `is_surjective && is_injective`
+- `assignments.ml:394` -- basecase correctly uses `set` (not `+=`) when `can_skip_accumulation`
+- `assignments.ml:447-450` -- emits `Fetch { Constant 0.0 }` when `needs_init = true`
+- `assignments.ml:718-719` -- `Fetch { Constant 0.0 }` lowered to `Zero_out`
+- `low_level.ml:289-296` -- tracing sets `zero_initialized_by_code` on first-touch
+- `c_syntax.ml:332-335` -- `Zero_out` unconditionally expanded to zeroing loop
+- `c_syntax.ml:872` -- declaration emits `= {0}` when `zero_initialized_by_code`
+- `backends.ml:485-487` -- allocation uses `alloc_array` when `zero_initialized_by_code`
+
+### Test Files
+
+- `test/operations/top_down_prec.c.expected` -- line 95: `d[0] = single_to_bfloat16((float)0);` (the redundant zeroing)
+- `test/operations/top_down_prec-unoptimized.ll.expected` -- lines 3, 5: `zero_out` nodes
+- `test/operations/top_down_prec.cu.expected` -- no zeroing (CUDA inlines differently)
+- `test/operations/top_down_prec.metal.expected` -- no zeroing (Metal inlines differently)
+- `test/einsum/test_accumulation_semantics.ml` -- tests that genuinely need zeroing (diagonal tensor, reduction)
+
+## Approach
+
+### Step 1: Fix `is_surjective` for trivial-dimension projections
+
+In `indexing.ml`, the `is_surjective` function's final check should not count `Fixed_idx 0` axes where `dim <= 1`, since those positions are trivially covered:
+
+```ocaml
+(* Count how many LHS axes actually need coverage by iterator symbols *)
+let non_trivial_lhs_count =
+  Array.count2_exn proj.project_lhs proj.lhs_dims ~f:(fun idx dim ->
+    match idx with
+    | Fixed_idx 0 when dim <= 1 -> false  (* trivially covered *)
+    | _ -> true)
+in
+Set.length lhs_symbol_set >= non_trivial_lhs_count
+```
+
+This replaces the current `Set.length lhs_symbol_set >= Array.length proj.project_lhs` on line 241. The same fix should be applied in the `has_affine` branch (line 237) for consistency.
+
+This is the minimal fix for issue #420. After this change, `needs_init` will correctly be `false` for scalar pointwise operations and other all-dim-1 cases, and no `Zero_out` will be emitted for them.
+
+### Step 2: Fix dual zeroing in code generation (addresses #382 partially)
+
+In `c_syntax.ml`, when generating code for `Zero_out tn`, check the `traced_store` (already available in the compilation closure) to see if `zero_initialized_by_code` is true. If so, skip the explicit zeroing loop since the declaration `= {0}` already handles it:
+
+```ocaml
+| Zero_out tn ->
+    let traced = Hashtbl.find_exn traced_store tn in
+    if traced.Low_level.zero_initialized_by_code then
+      (* Declaration already zeroed this array with = {0} *)
+      empty
+    else
+      pp_ll
+        (Low_level.loop_over_dims (Lazy.force tn.dims) ~body:(fun idcs ->
+             Set { tn; idcs; llsc = Constant 0.0; debug = get_ident tn ^ " := 0" }))
+```
+
+This eliminates the double zeroing for first-touch `Zero_out` while preserving the explicit loop for re-zeroing between iterations (where `zero_initialized_by_code` is `false` because the tracing condition at `low_level.ml:291` requires no prior assignments).
+
+### Step 3: Update test expectations
+
+After both fixes:
+
+1. Regenerate `test/operations/top_down_prec.c.expected` -- the `d[0] = single_to_bfloat16((float)0);` line should disappear.
+2. Regenerate `test/operations/top_down_prec-unoptimized.ll.expected` -- `zero_out d<bfloat16>;` and possibly `zero_out n6<half>;` should disappear.
+3. Check and update any other affected `.expected` files (scan for `zero_out` and zeroing patterns).
+4. Run the full test suite to confirm no regressions, especially:
+   - `test/einsum/test_accumulation_semantics` (tests diagonal tensor and reduction that genuinely need zeroing)
+   - All other einsum and operation tests
+
+### Edge Cases
+
+- **Broadcasting**: When operands have different broadcast shapes, the projection may be non-injective (multiple RHS elements map to same LHS position). `is_surjective` already handles this correctly via the iterator symbol analysis -- the fix only changes the `Fixed_idx 0` trivial case.
+- **Multi-dimensional arrays where some dims are 1**: The fix correctly counts only non-trivial axes. An array with dims `[3, 1, 5]` would have `Fixed_idx 0` for the middle axis, and the check would require 2 unique symbols for the other 2 axes.
+- **Padding**: The fix is orthogonal to padding handling (`assignments.ml:426-441`). Padding resets use a separate code path.
+- **Re-zeroing between iterations**: Protected by the `zero_initialized_by_code` flag only being set on first-touch (line 291 checks `Hash_set.is_empty traced.assignments`).
+- **Backend uniformity**: C, CUDA, and Metal all use `c_syntax.ml` via the `C_syntax_config` module type, so the Step 2 fix applies uniformly.
+- **Device buffer allocation**: Unaffected -- `backends.ml:485-487` already skips `alloc_zeros` when `zero_initialized_by_code` is true.

--- a/docs/proposals/gh-ocannl-425.md
+++ b/docs/proposals/gh-ocannl-425.md
@@ -1,0 +1,56 @@
+# Proposal: Migrate slipshow presentations to v0.10.0 with Mermaid
+
+## Goal
+
+Upgrade the slipshow version used in the GH Pages workflow from v0.6.0 to v0.10.0 (the latest release), enabling Mermaid diagram support in slide decks, and add Mermaid diagrams where they improve clarity.
+
+## Acceptance Criteria
+
+- [ ] Update slipshow download URL in `.github/workflows/gh-pages-docs.yml` from `v0.6.0` to `v0.10.0`
+- [ ] All three slide decks compile without errors under the new version:
+  - `docs/slides-basics_backprop_training_codegen.md`
+  - `docs/slides-RL-REINFORCE.md`
+  - `docs/slides-shapes_and_einsum.md`
+- [ ] Address any new compiler warnings introduced by v0.10.0 (it added compile-time warnings for missing IDs, action parse failures, etc.)
+- [ ] Add Mermaid diagrams in at least two candidate locations (see Context below)
+- [ ] GH Pages deployment succeeds with the new version
+
+## Context
+
+### Version gap: v0.6.0 to v0.10.0
+
+Key changes across the upgrade path:
+
+- **v0.8.x**: Base improvements (details sparse in release notes)
+- **v0.9.0**: Added MermaidJS support (#205), syntax highlighting for all highlight.js languages, MathJax extensions, KaTeX support, carousel-fixed-size, removed confusing auto-generated IDs
+- **v0.10.0**: Added compile-time warnings (missing ID, duplicated ID, action parse failures, unknown attributes, missing files, frontmatter parse errors). Fixed drawing and keyboard shortcut issues.
+
+The tar asset naming convention (`slipshow-linux-x86_64.tar`) is unchanged, so the `--strip-components=1` extraction in the workflow should continue to work.
+
+### Release asset verification
+
+The v0.10.0 release publishes `slipshow-linux-x86_64.tar` (same filename pattern as v0.6.0), confirming the download URL only needs the version string updated.
+
+### Mermaid diagram candidates
+
+After reviewing all three slide decks, the following locations are strong candidates for Mermaid diagrams:
+
+1. **Backprop computation flow** (basics slides, around line 463-470): The forward/backward pass explanation describes a computation chain `x -> y(x) -> f(y(x))` and the reverse gradient flow `df -> df/dy -> df/dx`. A Mermaid flowchart would visualize this clearly.
+
+2. **RL agent-environment loop** (RL slides, around line 14-25): The RL framework lists Agent, Environment, Actions, States, Rewards as bullet points. A Mermaid diagram showing the cyclic interaction (Agent --action--> Environment --state,reward--> Agent) is a classic RL visualization.
+
+3. **REINFORCE to GRPO evolution** (RL slides, around line 568-574): The numbered progression from REINFORCE through clipping, KL penalty, group baselines to GRPO could be a flowchart showing the additive enhancements.
+
+4. **Three axis kinds** (shapes slides, around line 49-55): The batch | input -> output tensor layout could be visualized as a diagram showing how the three axis kinds relate in matrix operations.
+
+### Risk: breaking changes
+
+The removal of auto-generated IDs in v0.9.0 could affect slides that implicitly relied on them. The new compile-time warnings in v0.10.0 will flag any such issues, making them easy to find and fix.
+
+### Code pointers
+
+- `.github/workflows/gh-pages-docs.yml:20` -- slipshow download URL (change `v0.6.0` to `v0.10.0`)
+- `dune-project:140` -- slipshow listed as doc dependency (version constraint may need update)
+- `docs/slides-basics_backprop_training_codegen.md` -- 871 lines, main tutorial
+- `docs/slides-RL-REINFORCE.md` -- 592 lines, RL tutorial
+- `docs/slides-shapes_and_einsum.md` -- 565 lines, shapes/einsum tutorial

--- a/docs/proposals/gh-ocannl-427.md
+++ b/docs/proposals/gh-ocannl-427.md
@@ -1,0 +1,140 @@
+# Proposal: Reproduce Small-Size Transformer Digit Addition Results
+
+## Goal
+
+Demonstrate that OCANNL's transformer building blocks can train a tiny transformer (~500-1000 parameters) to learn multi-digit addition from scratch, reproducing the "grokking" phenomenon where accuracy suddenly jumps after extended training. This validates OCANNL as a viable framework for algorithmic learning tasks and serves as a precursor to the decoder-only autoregressive transformer example (gh-ocannl-57).
+
+## Acceptance Criteria
+
+1. **Data generator**: A function that generates random N-digit addition problems as token sequences of the form `A+B=R` where R is the reversed-digit sum (LSB first). Vocab: digits 0-9, `+`, `=`, PAD (13 tokens). Configurable digit count (3-10). On-the-fly generation (no static dataset).
+
+2. **Model**: A decoder-only transformer using existing `multi_head_attention`, `mlp`, and causal mask infrastructure from `nn_blocks.ml`, with ~500-1000 trainable parameters. Hyperparameters: 1 layer, 1 attention head, d_model=16, d_ff=32 (tunable).
+
+3. **Training**: SGD training loop following the `fsm_transformer.ml` pattern (manual epoch/batch loop, `grad_update` + `sgd_update`, linear LR schedule). On-the-fly batch generation. Training for sufficient steps (10k-50k+) to observe grokking.
+
+4. **Evaluation**: Periodic evaluation on freshly generated test problems. Report exact-match accuracy (all result digits correct). The test should pass a threshold demonstrating the model learned to add (e.g., >80% exact-match accuracy on 3-digit addition).
+
+5. **Integration**: New file `test/training/digit_addition.ml` with corresponding dune test entry. Runs as a standard `dune test` target.
+
+## Context
+
+### Existing Building Blocks
+
+- **`multi_head_attention`** (`lib/nn_blocks.ml:181-209`): Q/K/V projections, scaled dot-product attention, multi-head via einsum, optional causal mask, dropout. Supports RoPE and sinusoidal position embeddings.
+
+- **`mlp`** (`lib/nn_blocks.ml:89-96`): Variable-depth MLP with ReLU activations and linear output. Used as the FFN in transformer blocks.
+
+- **`softmax`** (`lib/nn_blocks.ml:107-113`): Numerically stable (max subtraction), axis-specified via `~spec`.
+
+- **`layer_norm`** (`lib/nn_blocks.ml:211-218`): Learnable gamma/beta. Note: `fsm_transformer.ml` omits layer norm for tiny models because recentered weights + normalization can kill gradient signal. We should experiment with and without.
+
+- **Causal mask**: Lower-triangular matrix pattern used in `fsm_transformer.ml:103-108` and `transformer_test.ml:57-69`.
+
+- **Initialization**: `kaiming` and `xavier` initializers available in `nn_blocks.ml:31-53`. Alternatively, the manual recentering approach from `fsm_transformer.ml:168-174` (shift uniform[0,1) to centered range).
+
+### Reference Implementation Pattern: `fsm_transformer.ml`
+
+This is the closest existing example. It trains a single-block decoder-only transformer on FSM next-state prediction. Key patterns to follow:
+
+- **Data**: One-hot encoded sequences, flat arrays loaded via `Tn.set_values` (lines 51-59).
+- **Model**: Manual assembly of `multi_head_attention` + `mlp` with residual connections, no layer norm (lines 116-124).
+- **Compilation**: Separate training and inference compilation paths sharing weights (lines 128-194).
+- **Training loop**: Manual epoch/batch iteration, `grad_update` + `sgd_update`, linear LR warmdown (lines 200-226).
+- **Evaluation**: Separate inference routine compiled from same model, argmax prediction (lines 236-258).
+- **Weight init**: Post-init recentering to avoid exp overflow in attention (lines 168-174).
+
+### Reference Implementation Pattern: `bigram_mlp.ml`
+
+Training loop with batched data, LR scheduling, SGD, and inference via `%cd` for weight sharing.
+
+### Papers
+
+1. Havinga "gpt-acc-jax": ~777 parameter transformer learns 10-digit addition
+2. Zhu "A 456-Parameter Transformer Solves 10-Digit Addition": even smaller model
+
+Key insight from papers: reversed output digits (LSB first) are critical — the model can propagate carry information left-to-right through the autoregressive sequence.
+
+## Approach
+
+### 1. Data Generation
+
+```
+Sequence format: d₁d₂...dₙ+d₁d₂...dₙ=rₘrₘ₋₁...r₁[PAD...]
+```
+
+- Input: two N-digit numbers A, B (zero-padded to N digits)
+- Output: sum digits reversed (LSB first), zero-padded to N+1 positions (to handle carry overflow)
+- Total sequence length: N + 1 + N + 1 + (N+1) = 3N + 3
+- Vocab: 0-9 (digits), 10 (+), 11 (=), 12 (PAD) — 13 tokens
+- One-hot encode each token position
+- Generate batches on-the-fly using `Random.State`
+
+For a decoder-only (GPT-style) setup: the model sees the full concatenated sequence and is trained to predict the next token at every position. Loss is computed only on the result portion (after `=`), since the input portion is deterministic given the problem.
+
+### 2. Model Architecture
+
+Follow `fsm_transformer.ml` pattern — manual single-block decoder-only transformer:
+
+```
+input → embedding(13 → d_model) + learned_pos_encoding → 
+  residual(multi_head_attention(causal_mask)) →
+  residual(mlp(d_ff)) →
+  output_projection(d_model → 13)
+```
+
+Starting hyperparameters (targeting ~500-800 parameters):
+- `d_model = 16`
+- `num_heads = 1` (or 2 with `d_k = 8`)
+- `d_ff = 32`
+- `num_layers = 1`
+- Sequence length: 3*N + 3 (e.g., 12 for N=3)
+
+Parameter count estimate for N=3 (seq_len=12):
+- Embedding: 13 * 16 = 208
+- Pos encoding: 12 * 16 = 192
+- W_q, W_k, W_v: 3 * 16 * 16 = 768 (may be too many — reduce d_k)
+- W_o: 16 * 16 = 256
+- FFN W1: 16 * 32 = 512, b1: 32
+- FFN W_out: 32 * 16 = 512
+- Output projection: 16 * 13 = 208
+
+This exceeds the 777-parameter target. To reduce: use d_k = d_v = 8 (or lower), reduce d_ff, or use weight tying between embedding and output projection. The exact parameter budget will require experimentation.
+
+### 3. Training Loop
+
+- SGD with linear LR warmdown (following `fsm_transformer.ml` and `bigram_mlp.ml`)
+- On-the-fly batch generation: each batch is freshly generated random addition problems
+- Batch size: 32-64
+- Training steps: 10k-50k (grokking can take many apparently unproductive steps)
+- Every 500-1000 steps: evaluate on 1000 fresh test problems
+- Track and print: epoch loss, exact-match accuracy (all result digits correct)
+
+### 4. Evaluation
+
+- Generate 1000 fresh random addition problems
+- Run inference (forward-only, sharing trained weights)
+- For each problem: argmax decode the result tokens, compare to ground truth
+- Exact-match accuracy: all result digits must be correct
+- Print sample predictions for qualitative inspection
+- Test passes if accuracy exceeds threshold (e.g., >80% for 3-digit addition)
+
+### 5. File Structure
+
+- `test/training/digit_addition.ml` — main training script
+- Add dune test entry in `test/training/dune` (no external data dependencies, only `ocannl` library needed)
+
+### 6. Development Sequence
+
+1. Implement data generator and verify tokenization correctness
+2. Wire up model following `fsm_transformer.ml` pattern
+3. Implement training loop with loss tracking
+4. Add evaluation with exact-match accuracy
+5. Tune hyperparameters for grokking behavior
+6. Set regression thresholds for CI (conservative, not requiring full grokking)
+
+### Known Risks
+
+- **CUDA single-threaded kernels**: All CUDA kernels currently run with `grid_dim=1, block_dim=1`. This will make GPU training very slow for this task. CPU backend is likely faster for this model size.
+- **Parameter budget**: Hitting exactly 500-800 parameters while maintaining trainability may require multiple rounds of hyperparameter tuning.
+- **Grokking timing**: The phase transition can occur very late in training. CI test thresholds should be set conservatively (partial learning, not full grokking) to avoid flaky tests.
+- **Weight initialization**: As seen in `fsm_transformer.ml`, OCANNL's default uniform[0,1) init causes attention overflow. Must use recentering or the `kaiming`/`xavier` initializers from `nn_blocks.ml`.

--- a/docs/proposals/gh-ocannl-444-pope-support.md
+++ b/docs/proposals/gh-ocannl-444-pope-support.md
@@ -1,0 +1,104 @@
+# Proposal: PoPE (Polar Position Embeddings) support
+
+## Goal
+
+Add PoPE (arXiv:2509.10534) as a position embedding variant in OCANNL's transformer blocks. PoPE applies `softplus` to Q/K elements independently to produce magnitudes, which are then paired with position-only phases (from RoPE-style frequency/position angles). This maps `d` scalars to `2d` real values, doubling the per-head dimensionality, unlike RoPE which rotates pairs in-place.
+
+## Acceptance Criteria
+
+- [ ] Add `softplus` unary op to `tensor/operation.ml` with forward `log(1 + exp(x))` and gradient `sigmoid(x) = 1/(1 + exp(-x))`
+- [ ] Add `PoPE of { freqs : Tensor.t; positions : Tensor.t }` variant to `position_embedding` type in `nn_blocks.ml`
+- [ ] Support separate projection width in `multi_head_attention`: when PoPE is used, Q/K are projected to `d_k/2` (the "content" dimension), then PoPE doubles it back to `d_k` via magnitude-phase pairing
+- [ ] PoPE transform: given projected Q/K of width `d_k/2`, compute `mu = softplus(x)` for magnitudes, then output `interleave(mu * cos(angle), mu * sin(angle))` where angles come from `positions * freqs` (reusing existing `rope_frequencies` and `position_indices`)
+- [ ] The score computation uses the full `d_k`-width Q/K (after PoPE expansion), so the existing einsum and `sqrt(dim d)` scaling work unchanged
+- [ ] Gradients flow correctly through softplus and the magnitude-phase computation
+- [ ] No regression in existing tests (`attention_test.ml`, `rope_test.ml`, `transformer_test.ml`)
+- [ ] New test verifying PoPE attention forward pass shape, gradient flow, and numerical sanity (softplus outputs are non-negative)
+- [ ] `assert (d_k mod 2 = 0)` when PoPE is used (same as RoPE)
+
+## Context
+
+### Current state (verified)
+
+- **RoPE is fully implemented**: `position_embedding` type already has `RoPE of { freqs; positions }` variant. The `rope` function, `rope_frequencies`, `position_indices`, `interleave`/`deinterleave_even`/`deinterleave_odd` are all in place and tested.
+- **`multi_head_attention`** (`nn_blocks.ml:181-209`): Takes `~d_k ~d_v` params, projects Q/K/V via inline params `{ w_q }`, `{ w_k }`, `{ w_v }`. The dim `d` is set to `d_k` at line 200. RoPE is applied between projection and score computation (lines 190-193).
+- **Softplus is NOT available** as a primitive unary op. Available unary ops: `relu`, `sat01`, `exp`, `log`, `exp2`, `log2`, `sin`, `cos`, `sqrt`, `tanh`, `recip`, `recip_sqrt`. The `%cd` DSL for assignment-level code does not have `softplus` or `sigmoid` as primitives.
+- **Interleave/deinterleave ops** are available in `tensor/operation.ml` and exposed in the DSL. They handle even/odd pair splitting/merging on the last output axis.
+- **Existing PoPE placeholder**: A comment at `nn_blocks.ml:129-131` explicitly defers PoPE to #444.
+- **#398 proposal** (`docs/proposals/gh-ocannl-398.md`): Confirms PoPE was deferred because it doubles dimensionality and requires decoupling projection width from head width.
+
+### Key difference from RoPE
+
+RoPE rotates existing (x_even, x_odd) pairs in-place -- the output has the same dimensionality as the input. PoPE instead:
+1. Takes a `d/2`-dimensional content vector (from a narrower Q/K projection)
+2. Computes magnitude `mu_i = softplus(x_i)` for each of the `d/2` components
+3. Computes phase `theta_i = positions * freqs_i` (same as RoPE frequencies)
+4. Outputs `d`-dimensional vector: `interleave(mu * cos(theta), mu * sin(theta))`
+
+This means the Q/K projection weights `w_q`, `w_k` must project to `d_k/2` output dimensions when PoPE is active, while the score einsum still operates on the full `d_k` width (after PoPE expansion).
+
+## Approach
+
+### 1. Add `softplus` unary op (`tensor/operation.ml`)
+
+Follow the pattern of existing unary ops (e.g., `relu` at line 166). Since `softplus(x) = log(1 + exp(x))` and its gradient is `sigmoid(x) = 1/(1+exp(-x))`, and these don't exist as `%cd` primitives, implement using the existing `exp` and `log` primitives at the tensor op level:
+
+```
+let softplus x = log(1 + exp(x))
+```
+
+For gradient, express sigmoid as a composition: `exp(x) / (1 + exp(x))`, or equivalently reuse the forward value: `1 - exp(-softplus(x))`. This avoids needing a new `%cd` primitive -- softplus can be defined as a composite operation using existing `log` and `exp` ops. However, for numerical stability and efficiency, it is better to add `softplus` and `sigmoid` as native `%cd` assignments primitives in `arrayjit/lib/assignments.ml`, mirroring how `relu` and `relu_gate` are defined.
+
+Decision point: composite vs native. Native is preferred for numerical stability (avoids overflow for large x). The implementer should add `Softplus` and `Sigmoid` to the low-level assignment ops.
+
+### 2. Add `PoPE` variant to `position_embedding` type
+
+```ocaml
+type position_embedding =
+  | Learned_additive
+  | Sinusoidal_additive of { enc_encoding : Tensor.t; dec_encoding : Tensor.t }
+  | RoPE of { freqs : Tensor.t; positions : Tensor.t }
+  | PoPE of { freqs : Tensor.t; positions : Tensor.t }
+  | No_pos_embed
+```
+
+### 3. Implement `pope` transform function
+
+In `nn_blocks.ml`, alongside the existing `rope` function:
+
+```ocaml
+let%op pope ~freqs ~positions x =
+  let cos_a = cos (positions *. freqs) in
+  let sin_a = sin (positions *. freqs) in
+  let mu = softplus x in
+  interleave (mu *. cos_a) (mu *. sin_a)
+```
+
+Note: `x` here has output dim `d_k/2`, `freqs` has output dim `d_k/2`, result has output dim `d_k`.
+
+### 4. Modify `multi_head_attention` for PoPE
+
+The key change: when `pos_embed = PoPE _`, the projection dimension for Q/K is `d_k/2` instead of `d_k`. This requires setting the `d` shape dimension differently before vs after PoPE expansion:
+
+- Project Q/K with output width `d_k/2` (set dim constraint before projection)
+- Apply PoPE to expand to `d_k`
+- Score computation uses full `d_k` as before
+
+Implementation: add a `d_proj` local variable that is `d_k/2` for PoPE and `d_k` otherwise, and use `Shape.set_dim` appropriately on a separate dimension variable for the projection.
+
+### 5. Update `transformer` and decoder blocks
+
+Add `PoPE` case alongside `RoPE` in pattern matches throughout `transformer_encoder_block`, `transformer_decoder_block`, `transformer_encoder`, `transformer_decoder`, and `transformer`. These are straightforward -- PoPE behaves like RoPE in that it is applied inside attention (not as additive embedding).
+
+### 6. Tests
+
+Add `test/operations/pope_test.ml` (or extend `rope_test.ml`):
+- Verify shape: input `d_k/2` -> output `d_k` after PoPE
+- Verify softplus non-negativity of magnitudes
+- Verify gradient flow through the full attention pipeline with PoPE
+- Compare against hand-computed values for a small example
+
+### Prerequisites
+
+- **Softplus as `%cd` primitive**: Requires changes to `arrayjit/lib/assignments.ml` to add `Softplus` and `Sigmoid` (or `Sigmoid_gate`) to the low-level assignment language, then backend codegen support in CPU and CUDA/Metal backends. This is the main prerequisite work.
+- **No external blockers**: RoPE (#398) is complete. The infrastructure (interleave, deinterleave, frequencies, position indices) is all in place.

--- a/docs/proposals/gh-ocannl-54.md
+++ b/docs/proposals/gh-ocannl-54.md
@@ -1,0 +1,97 @@
+# Proposal: Polish MNIST and CIFAR Classifier Examples
+
+**Task:** gh-ocannl-54 — Add examples: MNIST and CIFAR classifiers
+**Issue:** https://github.com/ahrefs/ocannl/issues/54
+**Milestone:** v0.7.1
+
+## Goal
+
+Finalize the MNIST and CIFAR-10 classifier examples so they serve as polished, well-documented
+tutorials for OCANNL's CNN pipeline. The core implementations already exist
+(`test/training/mnist_conv.ml`, `test/training/cifar_conv.ml`) and pass regression tests. This
+task completes the remaining acceptance criteria: ensuring `dataprep` integration for CIFAR data
+loading, updating the README checkpoint, and verifying documentation quality.
+
+## Acceptance Criteria
+
+1. **MNIST classifier trains and achieves reasonable accuracy.**
+   - Already satisfied: `mnist_conv.ml` trains LeNet on MNIST, reaches 27.9% on 2K-sample
+     regression subset (above 25% threshold, well above 10% random chance). Full-run mode
+     documented to target >95% with 60K samples / 20 epochs.
+
+2. **CIFAR-10 classifier trains and achieves reasonable accuracy.**
+   - Already satisfied: `cifar_conv.ml` trains LeNet on CIFAR-10, reaches 19.9% on 2K-sample
+     regression subset (above 15% threshold). Full-run mode documented to target >60% with wider
+     channels and 50K samples / 50 epochs.
+
+3. **Examples use the `dataprep` package for data loading.**
+   - MNIST: satisfied — uses `Dataprep.Mnist.load`.
+   - CIFAR: partially satisfied — uses custom `Conv_data.load_cifar10` because
+     `Dataprep.Cifar10.load` is broken (downloads Python pickle format instead of binary).
+     Either fix the `Dataprep.Cifar10` loader in `ocaml-dataprep`, or document the workaround
+     as intentional. The current approach is reasonable and self-contained.
+
+4. **Examples are added as test executables in `test/training/dune`.**
+   - Already satisfied: both `mnist_conv` and `cifar_conv` have `(test ...)` stanzas with
+     correct dependencies (`ocannl`, `dataprep`, `conv_data`, `unix`).
+
+5. **README.md checkbox for convnet examples can be checked off.**
+   - Not yet done: `README.md` line 72 still shows `- [ ] Add convnet examples: MNIST and CIFAR.`
+   - Action: change to `- [x]`.
+
+## Context
+
+### Existing code (all committed to `master`)
+
+| File | Purpose | Lines |
+|------|---------|-------|
+| `test/training/mnist_conv.ml` | MNIST LeNet classifier with train/eval | 204 |
+| `test/training/cifar_conv.ml` | CIFAR-10 LeNet classifier with train/eval | 215 |
+| `test/training/conv_data.ml` | int8→float32 conversion, CIFAR binary loader | 165 |
+| `test/training/mnist_conv.expected` | Regression test expected output | 24 |
+| `test/training/cifar_conv.expected` | Regression test expected output | 24 |
+| `test/training/dune` | Build stanzas for both tests | relevant stanzas at lines 54-74 |
+
+### Architecture used
+
+Both examples use `Nn_blocks.lenet` (5x5 conv → relu → pool → 5x5 conv → relu → pool → fc120 → fc84 → logits) with `softmax` cross-entropy loss and SGD with linear learning rate decay. The earlier `circles_conv.ml` row variable mismatch issue documented in the task elaboration has been resolved — `lenet` composes `conv2d` and `max_pool2d` successfully.
+
+### Data pipeline
+
+- **MNIST**: `Dataprep.Mnist.load` → `Conv_data.mnist_images_to_float32` (adds channel dim, normalizes to [0,1]) → `Conv_data.labels_to_int_list` → `Nn_blocks.one_hot_of_int_list`
+- **CIFAR-10**: `Conv_data.load_cifar10` (custom binary downloader/parser, CHW→HWC) → `Conv_data.cifar_images_to_float32` (normalizes to [-0.5, 0.5] for zero-centered activations) → same label pipeline
+
+### Related proposals
+
+- `docs/proposals/convnet-examples.md` — earlier proposal that guided the initial implementation.
+
+## Approach
+
+Since the core implementation is complete and passing tests, the remaining work is minimal:
+
+### 1. Check README checkbox
+Change `README.md` line 72 from `- [ ]` to `- [x]` for the convnet examples item.
+
+### 2. Verify CIFAR `dataprep` criterion
+The acceptance criterion says "Examples use the `dataprep` package for data loading." The CIFAR
+example uses a custom loader (`Conv_data.load_cifar10`) because the `dataprep` CIFAR loader is
+broken. Two options:
+- **Option A (recommended):** Accept the current `Conv_data.load_cifar10` as sufficient — it
+  downloads, caches, and parses CIFAR-10 binary data correctly. Add a comment noting this is a
+  workaround for the broken `Dataprep.Cifar10` loader. (Already documented in `cifar_conv.ml`
+  header and `conv_data.ml` docstring.)
+- **Option B:** Fix `Dataprep.Cifar10.load` in `ocaml-dataprep` to use the binary format. This
+  is a separate task in a different repo.
+
+### 3. Review documentation quality
+Both files already have:
+- Module-level doc comments explaining purpose, regression vs full-run modes, and manual validation commands
+- Inline comments explaining each step (data loading, conversion, model setup, loss, training loop, evaluation)
+- Clear separation of configuration constants with full-run values in comments
+
+### 4. Verify `dune runtest` passes
+Run `OCANNL_BACKEND=sync_cc dune runtest` to confirm both examples produce expected output. (They are already committed with `.expected` files that match.)
+
+### Estimated effort
+Minimal — 1-2 hours. The substantive implementation work is done. This is checkbox-checking
+and final review.

--- a/docs/proposals/task-bb30d0be.md
+++ b/docs/proposals/task-bb30d0be.md
@@ -1,0 +1,120 @@
+# Fix broken test suite: OCANNL
+
+**Task**: task-bb30d0be  
+**Project**: OCANNL  
+**Date**: 2026-04-07  
+**Status**: Ready to implement
+
+## Goal
+
+Restore `dune runtest` to exit code 0 by fixing two independent test failures introduced in recent
+commits.
+
+## Acceptance Criteria
+
+- `dune runtest` exits with code 0 (all tests pass)
+- `arrayjit/test/test_ndarray_binary_io.expected` includes the two log-level debug lines that the
+  current code always emits when `log_level=0`
+- `tensor/shape.ml` `derive_projections` no longer crashes with a duplicate-key exception when
+  building `symbol_to_proj` for convolution/pooling cases where output_size=1
+
+## Context
+
+Two unrelated test failures exist as of 2026-04-07:
+
+### Failure 1: `arrayjit/test/test_ndarray_binary_io` — output mismatch
+
+`dune runtest` diff shows two lines missing from the `.expected` file:
+
+```
++Retrieving commandline, environment, or config file variable ocannl_log_level
++Found 0, in the config file
+```
+
+Root cause: commit `b3262b2c` added `|| equal_string n "log_level"` to the `with_debug` condition
+in `arrayjit/lib/utils.ml:get_global_arg` (line 164). This causes the `log_level` lookup itself to
+always emit debug output, regardless of the current log level — it is a self-referential special
+case. The `.expected` file for `test_ndarray_binary_io` was written after this commit but does not
+include these lines. The `test_max_pool2d.expected` file already contains them (confirmed), so only
+`test_ndarray_binary_io.expected` needs updating.
+
+### Failure 2: `test/einsum/test_max_pool2d` — fatal exception
+
+```
+Fatal error: exception ("Map.of_alist_exn: duplicate key" (Symbol 42))
+Called from Ocannl_tensor__Shape.derive_projections in file "tensor/shape.ml", lines 1899-1901
+```
+
+Root cause: `derive_projections` builds `symbol_to_proj` via `Map.of_alist_exn` over the result of
+`Row.product_dim_iterators`. For the `test_max_pool2d_output_dim_1` test case (3x3 input, window=3,
+stride=2 → 1x1 output), two different `proj_id`s both map to the same iterator symbol (Symbol 42).
+When the output dimension is 1, the `oh` dimension collapses and shares an iterator with one of the
+kernel dimensions, producing a duplicate key. `Map.of_alist_exn` panics on duplicates.
+
+This was introduced in commit `9100f654` (Concat projection unification). The `symbol_to_proj` map
+is subsequently used only via `Map.find` in `missing_entries` (line ~1943), so keeping just the
+first occurrence per symbol is semantically correct.
+
+## Approach
+
+### Fix 1: Update expected file (minimal, preferred)
+
+Prepend the two log-level lines to
+`arrayjit/test/test_ndarray_binary_io.expected`:
+
+```
+Retrieving commandline, environment, or config file variable ocannl_log_level
+Found 0, in the config file
+PASS: Byte
+...
+```
+
+This is the minimal fix that matches the current intended behavior (the `log_level` self-logging was
+deliberately added in `b3262b2c`). Removing the `|| equal_string n "log_level"` condition would be
+a behavioral regression and is out of scope for this bug fix.
+
+### Fix 2: Replace `Map.of_alist_exn` with `Map.of_alist_reduce` in `derive_projections`
+
+In `tensor/shape.ml` at lines 1898–1901, change:
+
+```ocaml
+let symbol_to_proj =
+  Map.of_alist_exn
+    (module Idx.Symbol)
+    (Row.product_dim_iterators proj_env |> List.map ~f:(fun (p, d, s) -> (s, (p, d))))
+in
+```
+
+to:
+
+```ocaml
+let symbol_to_proj =
+  Map.of_alist_reduce
+    (module Idx.Symbol)
+    (Row.product_dim_iterators proj_env |> List.map ~f:(fun (p, d, s) -> (s, (p, d))))
+    ~f:(fun first _second -> first)
+in
+```
+
+The `~f:(fun first _second -> first)` keeps the first mapping when duplicates occur, which is
+correct because the map is only queried to fill in entries for symbols not already present in
+`unique_by_iterator` (which was already deduplicated by symbol). The underlying cause — why two
+proj_ids share the same iterator symbol for 1x1 output — may be a deeper shape inference issue
+worth investigating separately, but that is out of scope here.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `arrayjit/test/test_ndarray_binary_io.expected` | Prepend 2 log-level lines |
+| `tensor/shape.ml` lines 1899–1901 | `Map.of_alist_exn` → `Map.of_alist_reduce ~f:(fun first _ -> first)` |
+
+## Verification
+
+After applying both fixes:
+
+```
+dune runtest
+```
+
+Should exit with code 0 with no diff output.

--- a/docs/proposals/task-d079849d.md
+++ b/docs/proposals/task-d079849d.md
@@ -1,0 +1,108 @@
+# Proposal: Fix build_files/ sharing between test executables
+
+## Goal
+
+Multiple OCANNL test executables write generated code files (`.ll`, `.c`, `.cu`, `.metal`, `.cd`) to a single shared `build_files/` directory using tensor-derived routine names as filenames. When dune runs tests in parallel within the same directory (e.g., `test/operations/` or `test/einsum/`), tests with overlapping routine names race on the same files, causing flaky diff-based test failures. The fix adds a configurable `build_files_prefix` so each test can use an isolated subdirectory.
+
+## Acceptance Criteria
+
+- [ ] A new config option `build_files_prefix` (string, default empty) is available via command line, environment variable, or `ocannl_config` file, following the existing config pattern
+- [ ] When `build_files_prefix` is set, the `build_file` function in `utils.ml` creates and uses `build_files/<prefix>/` as the output directory instead of the flat `build_files/`
+- [ ] The `clean_up_build_files_on_startup` logic also handles prefixed subdirectories (only cleans the specific prefix subdir, or the whole `build_files/` when no prefix is set)
+- [ ] All dune rules that copy files from `build_files/` are updated to use the prefixed paths: `build_files/<test-name>/filename` instead of `build_files/filename`
+- [ ] Each test executable that generates `build_files/` output is invoked with `--ocannl_build_files_prefix=<test-name>` in its dune rule
+- [ ] Running `dune runtest` passes with no flaky failures from `build_files/` collisions
+- [ ] Tests that do not use `build_files/` are unaffected
+
+## Context
+
+### The problem
+
+`Utils.build_file` (in `arrayjit/lib/utils.ml:227-231`) hardcodes the directory name:
+
+```ocaml
+let build_file fname =
+  let build_files_dir = "build_files" in
+  (try assert (Stdlib.Sys.is_directory build_files_dir)
+   with Stdlib.Sys_error _ -> Stdlib.Sys.mkdir build_files_dir 0o777);
+  filename_concat build_files_dir @@ clean_filename fname
+```
+
+All callers (`Utils.output_to_build_file`, `Utils.open_build_file`, `Utils.get_debug_output_channel`, and direct calls in `cc_backend.ml`, `cuda_backend.ml`, `metal_backend.ml`) go through this single function.
+
+### Affected test rules
+
+Tests that use `--ocannl_output_debug_files_in_build_directory=true` and copy results from `build_files/`:
+
+1. **`test/einsum/dune`**:
+   - `inline_permuted_view.exe` -> copies `build_files/c_fwd.ll`
+   - `test_cse.exe` -> copies `build_files/cse_d_fwd.ll`
+
+2. **`test/operations/dune`**:
+   - `threefry4x32_demo.exe` -> copies `build_files/n3_fwd-unoptimized.ll`
+   - `top_down_prec.exe` -> copies `build_files/d_fwd-unoptimized.ll` and `build_files/d_fwd.<ext>`
+   - `test_where_precision.exe` -> copies `build_files/where_fwd-unoptimized.ll` and `build_files/where_fwd.<ext>`
+
+The test config at `test/config/ocannl_config` already sets `clean_up_build_files_on_startup=false` (with the comment "Don't delete files as tests might be running in parallel") -- acknowledging the problem but not fully solving it, since filename collisions can still occur if two tests produce routines with the same name.
+
+### Related: DLL output
+
+`cc_backend.ml:69` has a similar pattern with `output_dlls_in_build_directory` placing compiled `.so`/`.dll` files into `build_files/`. These also benefit from the prefix to avoid collisions.
+
+## Approach
+
+### 1. Add `build_files_prefix` config option to `utils.ml`
+
+In the `build_file` function, read a new `build_files_prefix` global arg. When non-empty, use `build_files/<prefix>/` as the directory:
+
+```ocaml
+let build_file fname =
+  let prefix = get_global_arg ~default:"" ~arg_name:"build_files_prefix" in
+  let build_files_dir =
+    if String.is_empty prefix then "build_files"
+    else filename_concat "build_files" (clean_filename prefix)
+  in
+  (try assert (Stdlib.Sys.is_directory build_files_dir)
+   with Stdlib.Sys_error _ ->
+     (* Create parent and subdir *)
+     (try assert (Stdlib.Sys.is_directory "build_files")
+      with Stdlib.Sys_error _ -> Stdlib.Sys.mkdir "build_files" 0o777);
+     if not (String.is_empty prefix) then Stdlib.Sys.mkdir build_files_dir 0o777);
+  filename_concat build_files_dir @@ clean_filename fname
+```
+
+Since `get_global_arg` is evaluated at each call and the value comes from command line args, this naturally supports per-invocation prefixes.
+
+### 2. Update cleanup logic
+
+The `clean_up_build_files_on_startup` block (line ~261) should respect the prefix. When a prefix is set, only remove `build_files/<prefix>/`; when no prefix, remove the whole `build_files/` as before.
+
+### 3. Update dune rules
+
+For each test rule that runs an executable with `--ocannl_output_debug_files_in_build_directory=true`:
+
+- Add `--ocannl_build_files_prefix=<test-name>` to the run command
+- Update the `copy` path from `build_files/<file>` to `build_files/<test-name>/<file>`
+
+Example for `test/einsum/dune`:
+```
+(run %{dep:inline_permuted_view.exe}
+     "--ocannl_output_debug_files_in_build_directory=true"
+     "--ocannl_build_files_prefix=inline_permuted_view")
+(copy build_files/inline_permuted_view/c_fwd.ll %{target})
+```
+
+### 4. Add to config example
+
+Add `build_files_prefix=` to `ocannl_config.example` with documentation.
+
+### 5. Update `output_dlls_in_build_directory` path in `cc_backend.ml`
+
+The DLL output path at `cc_backend.ml:69-71` uses `build_file` indirectly (via `base_name` from `f_path`), so it will automatically pick up the prefix through the `build_file` function. No additional changes needed there.
+
+### Files to modify
+
+- `arrayjit/lib/utils.ml` -- `build_file` function and cleanup logic
+- `test/einsum/dune` -- 2 rules (inline_permuted_view, test_cse)
+- `test/operations/dune` -- 3 rules (threefry4x32_demo, top_down_prec, test_where_precision)
+- `ocannl_config.example` -- document new option

--- a/docs/proposals/watch-ocannl-README-md-177e6c0e.md
+++ b/docs/proposals/watch-ocannl-README-md-177e6c0e.md
@@ -1,0 +1,107 @@
+# Proposal: Transformer Inference for a Small Open-Weights Model
+
+## Goal
+
+Build an end-to-end inference pipeline that loads pre-trained GPT-2 small (124M parameters) weights, tokenizes a text prompt, runs a forward pass through a decoder-only transformer, and generates coherent text autoregressively. This demonstrates OCANNL's ability to run real pre-trained models and serves as a flagship example for the v0.7.1 milestone.
+
+GitHub issue: https://github.com/ahrefs/ocannl/issues/377
+ROADMAP.md v0.7.1: "Transformer inference demo (#377)"
+
+## Acceptance Criteria
+
+- [ ] GPT-2 small (124M) weights are converted to OCANNL checkpoint format via a Python helper script, and loaded using `Persistence.load`/`Persistence.restore`
+- [ ] A decoder-only transformer architecture matching GPT-2 small is implemented: 12 layers, 12 heads, d_model=768, d_ff=3072, pre-layer-norm, GeLU activation, learned positional embeddings
+- [ ] GeLU activation is added to `nn_blocks.ml` (tanh approximation using existing ops)
+- [ ] A `decoder_only_block` and `decoder_only_transformer` are added to `nn_blocks.ml` (pre-layer-norm, masked self-attention, GeLU FFN, no cross-attention)
+- [ ] Tokenization uses the `Dataprep.Bpe_tokenizer` from `ocaml-dataprep` (or a minimal BPE implementation if the dataprep tokenizer is not yet available for GPT-2's vocabulary)
+- [ ] The inference script produces coherent, recognizable English text from a given prompt (e.g., "The quick brown fox")
+- [ ] Forward pass logits match HuggingFace GPT-2 reference output within float32 tolerance (~1e-4 relative error) on a short test sequence
+- [ ] Autoregressive generation supports temperature and top-k sampling
+- [ ] The example runs end-to-end on CPU in a reasonable time (< 30 seconds for generating 50 tokens)
+- [ ] The script is located at `test/training/gpt2_inference.ml` with a corresponding `.expected` file for CI
+
+## Context
+
+### What exists now
+
+**Tensor persistence** (`lib/persistence.ml`): `save`, `load`, and `restore` are fully implemented with a binary checkpoint format (s-expression header + raw tensor data). `load` creates fresh tnodes from file; `restore` overwrites existing tnode data. This is the foundation for weight loading.
+
+**Transformer blocks** (`lib/nn_blocks.ml`):
+- `multi_head_attention` (line 115): separate Q/K/V projections, optional mask, temperature scaling, dropout
+- `layer_norm` (line 136): learnable gamma/beta normalization
+- `transformer_encoder_block` (line 145): self-attention + FFN with post-layer-norm (close to what's needed but uses post-norm and ReLU)
+- `transformer` (line 202): encoder-decoder architecture (not decoder-only)
+- `softmax` (line 106): numerically stable with temperature
+
+**No decoder-only block in nn_blocks.ml**: The `transformer_encoder_block` is the closest match but uses post-layer-norm and lacks a `~mask` parameter. The Names transformer proposal (watch-ocannl-README-md-369aadb4) specifies adding `decoder_only_block` to nn_blocks.ml, but it has not been implemented yet.
+
+**No GeLU/SiLU activations**: Only ReLU, Exp, Log, Sin, Cos, Sqrt, Neg, Tanh_approx exist. GeLU can be composed: `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))`.
+
+**RoPE** (gh-ocannl-398): The issue is closed but no RoPE code exists in `lib/`. Not needed for GPT-2 (which uses learned positional embeddings), but would be needed for LLaMA/Gemma follow-up.
+
+**Tokenizer** (dataprep): The `Dataprep` package is already an opam dependency. `Dataprep.Names` provides character-level tokenization. A BPE tokenizer (`Dataprep.Bpe_tokenizer`) is being developed in `ocaml-dataprep`. If not ready, a minimal GPT-2 BPE decoder can be implemented inline.
+
+### Architecture: GPT-2 Small
+
+```
+vocab_size: 50257
+n_positions: 1024
+n_embd: 768
+n_layer: 12
+n_head: 12
+d_k = d_v = 64 (768 / 12)
+d_ff: 3072 (4 * 768)
+activation: GeLU
+layer_norm: pre-norm (before attention and FFN)
+positional: learned absolute embeddings
+output: tied to token embedding (weight sharing)
+total parameters: ~124M (~500MB float32)
+```
+
+### Key technical challenges
+
+1. **Pre-layer-norm block**: The existing `transformer_encoder_block` uses post-norm. GPT-2 needs:
+   ```
+   x = x + mha(ln1(x))    -- pre-norm attention
+   x = x + ffn(ln2(x))    -- pre-norm FFN
+   ```
+
+2. **Fused QKV projection**: GPT-2's `c_attn.weight` is a single (768 x 2304) matrix computing Q, K, V together. OCANNL's `multi_head_attention` uses separate `w_q`, `w_k`, `w_v`. The weight converter must split the fused weight into three (768 x 768) matrices.
+
+3. **Weight mapping**: GPT-2 HuggingFace safetensors use names like `h.0.attn.c_attn.weight`. The Python converter maps these to OCANNL tensor labels and writes the checkpoint file. The OCANNL side then constructs the model graph (which assigns tnode IDs) and uses `Persistence.restore` to fill in the weights.
+
+4. **Embedding lookup vs one-hot**: For vocab_size=50257, one-hot encoding is impractical (50K-dimensional vectors). Instead, use an integer-indexed embedding lookup. This may require a small utility or a creative use of einsum to select rows from the embedding matrix.
+
+5. **Token embedding tying**: GPT-2 reuses the input embedding matrix as the output projection (logits = hidden @ embedding^T). The checkpoint converter and model construction must share this weight.
+
+### Approach
+
+**Phase 1 -- nn_blocks.ml additions**:
+- Add `gelu` activation function
+- Add `decoder_only_block` with pre-layer-norm, masked self-attention, configurable FFN activation
+- Add `decoder_only_transformer` that stacks N blocks with embedding + final layer norm
+
+**Phase 2 -- Weight conversion**:
+- Python script (`scripts/convert_gpt2_weights.py`) that downloads GPT-2 small from HuggingFace, splits fused QKV, and writes OCANNL checkpoint format
+- The script must produce a checkpoint file matching the tnode IDs/labels that the OCaml model graph will create
+
+**Phase 3 -- Tokenization bridge**:
+- If `Dataprep.Bpe_tokenizer` supports GPT-2 vocab: use it directly
+- Otherwise: minimal GPT-2 BPE implementation reading the published `vocab.bpe` and `encoder.json` files
+
+**Phase 4 -- Inference script** (`test/training/gpt2_inference.ml`):
+- Construct GPT-2 model graph
+- Load weights from checkpoint
+- Encode prompt -> run forward pass -> sample next token -> loop
+- Print generated text
+
+**Phase 5 -- Validation**:
+- Compare logits against HuggingFace reference on a fixed prompt
+- Verify greedy decoding produces identical output
+
+### Dependencies
+
+- **gh-ocannl-373** (Tensor persistence): DONE -- `Persistence.{save,load,restore}` available
+- **watch-ocannl-README-md-ebb316ea** (Tokenizers): In progress in `ocaml-dataprep`. Can work around with inline BPE if not ready.
+- **watch-ocannl-README-md-369aadb4** (Names transformer): Not yet implemented, but this task will independently add `decoder_only_block` to nn_blocks.ml (the Names example can then reuse it)
+- **gh-ocannl-398** (RoPE): Not needed for GPT-2. Relevant for future LLaMA/Gemma work.

--- a/test/operations/layer_norm_test.ml
+++ b/test/operations/layer_norm_test.ml
@@ -1,20 +1,6 @@
 open! Base
 open Ocannl.Nn_blocks.DSL_modules
 
-let%op mini_decoder_block ~label ~num_heads ~d_k ~d_v ~d_ff ?(epsilon = 1e-5) () =
-  let open Ocannl.Nn_blocks in
-  let masked_mha = multi_head_attention ~label:("masked_mha" :: label) ~num_heads ~d_k ~d_v () in
-  (* Standard 2-layer FFN: expand to d_ff then contract back to d_model *)
-  let ffn = mlp ~label:("ffn" :: label) ~hid_dims:[ d_ff ] () in
-  let ln1 = layer_norm ~label:("ln1" :: label) ~epsilon () in
-  let ln2 = layer_norm ~label:("ln2" :: label) ~epsilon () in
-  fun ~train_step target ~mask ->
-    let x1 = ln1 (target + masked_mha ~train_step ~mask target) in
-    ln2 (x1 + ffn x1)
-
-open! Base
-open Ocannl.Nn_blocks.DSL_modules
-
 let () =
   (* Basic transformer test *)
   let ctx = Context.auto () in
@@ -30,7 +16,8 @@ let () =
 
   (* Create a simple transformer model *)
   let mini_decoder_model =
-    mini_decoder_block ~label:[ "test_mini_decoder" ] ~num_heads ~d_k:d_model ~d_v:d_model ~d_ff ()
+    Ocannl.Nn_blocks.decoder_only_block ~label:[ "test_mini_decoder" ] ~num_heads ~d_k:d_model
+      ~d_v:d_model ~d_ff ()
   in
 
   let tgt =

--- a/test/training/dune
+++ b/test/training/dune
@@ -74,6 +74,17 @@
   (pps ppx_here ppx_ocannl)))
 
 (test
+ (name fsm_transformer)
+ (package neural_nets_lib)
+ (modules fsm_transformer)
+ (deps
+  ocannl_config
+  (env_var OCANNL_BACKEND))
+ (libraries ocannl)
+ (preprocess
+  (pps ppx_here ppx_ocannl)))
+
+(test
  (name transformer_names)
  (package neural_nets_lib)
  (modules transformer_names)

--- a/test/training/fsm_transformer.expected
+++ b/test/training/fsm_transformer.expected
@@ -1,0 +1,6 @@
+Retrieving commandline, environment, or config file variable ocannl_log_level
+Found 0, in the config file
+Epoch 0, loss below threshold=true
+Epoch 20, loss below threshold=true
+Epoch 39, loss below threshold=true
+Held-out valid-transition accuracy above 0.90=true

--- a/test/training/fsm_transformer.ml
+++ b/test/training/fsm_transformer.ml
@@ -1,0 +1,258 @@
+open Base
+open Ocannl
+open Stdio
+module Tn = Ir.Tnode
+module IDX = Train.IDX
+open Nn_blocks.DSL_modules
+module Asgns = Ir.Assignments
+
+(* === FSM Definition === *)
+
+let num_states = 8
+
+(* transition.(state).(input_bit) = next_state
+   A fixed deterministic FSM with 8 states and binary input.  All states are reachable
+   and every state has two distinct successors. *)
+let transition =
+  [|
+    [| 3; 5 |];
+    [| 6; 0 |];
+    [| 7; 4 |];
+    [| 1; 2 |];
+    [| 5; 7 |];
+    [| 0; 6 |];
+    [| 4; 1 |];
+    [| 2; 3 |];
+  |]
+
+let generate_sequence rng ~seq_len ~init_state =
+  let states = Array.create ~len:seq_len 0 in
+  states.(0) <- init_state;
+  for i = 1 to seq_len - 1 do
+    let bit = Random.State.int rng 2 in
+    states.(i) <- transition.(states.(i - 1)).(bit)
+  done;
+  states
+
+let generate_batch rng ~num_seqs ~seq_len =
+  let eff_seq_len = seq_len - 1 in
+  let inputs = Array.init num_seqs ~f:(fun _ -> Array.create ~len:eff_seq_len 0) in
+  let targets = Array.init num_seqs ~f:(fun _ -> Array.create ~len:eff_seq_len 0) in
+  for i = 0 to num_seqs - 1 do
+    let init_state = Random.State.int rng num_states in
+    let seq = generate_sequence rng ~seq_len ~init_state in
+    for t = 0 to eff_seq_len - 1 do
+      inputs.(i).(t) <- seq.(t);
+      targets.(i).(t) <- seq.(t + 1)
+    done
+  done;
+  (inputs, targets)
+
+let seqs_to_flat_one_hot ~batch_size ~eff_seq_len (seqs : int array array) ~offset =
+  let flat = Array.create ~len:(batch_size * eff_seq_len * num_states) 0. in
+  for i = 0 to batch_size - 1 do
+    for t = 0 to eff_seq_len - 1 do
+      let base = ((i * eff_seq_len) + t) * num_states in
+      flat.(base + seqs.(offset + i).(t)) <- 1.
+    done
+  done;
+  flat
+
+(* === Main === *)
+
+let () =
+  Utils.settings.fixed_state_for_init <- Some 3;
+  Tensor.unsafe_reinitialize ();
+
+  let seq_len = 9 in
+  let eff_seq_len = seq_len - 1 in
+  let batch_size = 32 in
+  let num_train_seqs = 256 in
+  let num_test_seqs = 32 in
+  let d_model = 16 in
+  let num_heads = 2 in
+  let d_k = 8 in
+  let d_v = 8 in
+  let d_ff = 32 in
+  let epochs = 40 in
+
+  let train_rng = Random.State.make [| 42 |] in
+  let train_inputs_arr, train_targets_arr =
+    generate_batch train_rng ~num_seqs:num_train_seqs ~seq_len
+  in
+  let test_rng = Random.State.make [| 99 |] in
+  let test_inputs_arr, _test_targets_arr =
+    generate_batch test_rng ~num_seqs:num_test_seqs ~seq_len
+  in
+
+  let n_batches = num_train_seqs / batch_size in
+  let step_n, bindings = IDX.get_static_symbol IDX.empty in
+  let total_tokens = batch_size * eff_seq_len in
+
+  let make_data_tensor label =
+    let open Bigarray in
+    let ga = Genarray.create Float32 c_layout [| batch_size; eff_seq_len; num_states |] in
+    Bigarray.Genarray.fill ga 0.;
+    let nd = Ir.Ndarray.as_array Ir.Ops.Single ga in
+    Tensor.term ~init_data:(Reshape nd) ~grad_spec:If_needed ~label:[ label ]
+      ~batch_dims:[ batch_size; eff_seq_len ] ~input_dims:[] ~output_dims:[ num_states ] ()
+  in
+  let input_batch = make_data_tensor "input_batch" in
+  let target_batch = make_data_tensor "target_batch" in
+
+  let mask =
+    NTDSL.init ~l:"mask" ~prec:Ir.Ops.single ~b:[ eff_seq_len ] ~i:[ eff_seq_len ] ~o:[]
+      ~f:(function
+        | [| s; t |] -> if s >= t then 1. else 0.
+        | _ -> failwith "unexpected mask indices")
+      ()
+  in
+
+  (* Model: decoder-only transformer (single block, no layer_norm).
+     Layer norm is omitted because with recentered weights, it normalizes values to
+     unit variance and kills the gradient signal.  Residual connections preserve
+     gradients for this small model. *)
+  let open Nn_blocks in
+  let mha = multi_head_attention ~label:[ "mha" ] ~num_heads ~d_k ~d_v () in
+  let ffn = Nn_blocks.mlp ~label:[ "ffn" ] ~hid_dims:[ d_ff ] () in
+  let%op build_model () =
+    fun ~train_step ~mask input ->
+      let embedded = ({ w_embed; o = [ d_model ] } * input) + { pos_encoding } in
+      let x1 = embedded + mha ~train_step ~mask embedded in
+      let x2 = x1 + ffn x1 in
+      { w_out } * x2
+  in
+  let model = build_model () in
+
+  (* === Training computation === *)
+  let train_logits = model ~train_step:(Some step_n) ~mask input_batch in
+  let%op counts = exp train_logits in
+  let%op probs = counts /. (counts ++ "...|... => ...|0") in
+  let%op output_probs = (probs *. target_batch) ++ "...|... => ...|0" in
+  let%op loss = neg (log output_probs) in
+  let%op batch_loss = (loss ++ "...|... => 0") /. !..total_tokens in
+
+  let update = Train.grad_update batch_loss in
+  let steps = epochs * n_batches in
+  let%op learning_rate = 1.0 *. ((1.5 *. !..steps) - !@step_n) /. !..steps in
+  let sgd = Train.sgd_update ~learning_rate batch_loss in
+
+  (* === Inference computation (forward-only, shares trained weights) ===
+     Following the bigram_mlp.ml pattern: invoke the model a second time via %cd
+     with a fresh input tensor.  This creates a separate forward graph that shares
+     the trained weight parameters but has its own (unconsumed) forward code. *)
+  let infer_input =
+    let open Bigarray in
+    let ga = Genarray.create Float32 c_layout [| num_test_seqs; eff_seq_len; num_states |] in
+    Bigarray.Genarray.fill ga 0.;
+    let nd = Ir.Ndarray.as_array Ir.Ops.Single ga in
+    Tensor.term ~init_data:(Reshape nd) ~grad_spec:Prohibit_grad ~label:[ "infer_input" ]
+      ~batch_dims:[ num_test_seqs; eff_seq_len ] ~input_dims:[] ~output_dims:[ num_states ] ()
+  in
+  let%cd infer_logits = model ~train_step:None ~mask infer_input in
+  let%cd infer_comp =
+    ~~("fsm infer";
+       infer_logits.forward)
+  in
+
+  (* === Compile === *)
+  let ctx = Context.auto () in
+  let ctx = Train.init_params ctx bindings batch_loss in
+  Train.set_on_host input_batch.value;
+  Train.set_on_host target_batch.value;
+  (* Recenter all model parameters from uniform [0,1) to [-0.25, 0.25).
+     OCANNL's default uniform1 init produces all-positive weights; through the
+     transformer's Q*K^T attention scores this causes extreme values and exp overflow.
+     Centered initialization (e.g. xavier/normal) is standard for transformers but
+     not yet available as a built-in default_param_init in OCANNL, so we recenter
+     post-init. *)
+  Set.iter batch_loss.Tensor.params ~f:(fun p ->
+      let tn = p.Tensor.value in
+      Train.set_on_host tn;
+      let vals = Tn.get_values tn in
+      Array.iteri vals ~f:(fun i v -> vals.(i) <- 0.5 *. (v -. 0.5));
+      Tn.set_values tn vals);
+  Train.set_on_host infer_logits.value;
+  Train.set_on_host infer_input.value;
+  (* Compile the training routine.  This adds all training nodes (including the
+     shared mask constant) to the context via Context.compile. *)
+  let train_comp = Asgns.sequence [ update; sgd ] in
+  Set.iter (snd @@ Asgns.collect_nodes_guess_output train_comp.Asgns.asgns) ~f:Train.set_hosted;
+  let ctx, sgd_step = Context.compile ctx train_comp bindings in
+  (* Compile the inference routine using the context from training compilation,
+     which already contains the mask constant and all model weight buffers.
+     This is forward-only: no backprop, no SGD update. *)
+  Set.iter (snd @@ Asgns.collect_nodes_guess_output infer_comp.Asgns.asgns) ~f:Train.set_hosted;
+  (* The mask constant is embedded in the training compilation but not in the inference
+     compilation (because consume_forward_code builds embedded_nodes independently for
+     each tensor).  Add mask to the inference comp's embedded_nodes so Context.compile
+     treats it as an embedded constant rather than an uninitialized input. *)
+  let infer_comp =
+    { infer_comp with
+      Asgns.embedded_nodes = Set.add infer_comp.Asgns.embedded_nodes mask.value }
+  in
+  let ctx, infer_routine = Context.compile ctx infer_comp IDX.empty in
+
+  let open Operation.At in
+  let step_ref = IDX.find_exn (Context.bindings sgd_step) step_n in
+  Train.set_on_host batch_loss.value;
+
+  (* === Training loop ===
+     Per-token random baseline: ln(8) ≈ 2.08, epoch sum ≈ 2.08 * n_batches ≈ 16.6.
+     Optimal loss for binary FSM: ln(2) ≈ 0.693 per token, epoch sum ≈ 5.5. *)
+  let epoch_loss_limit_first = 16.0 in
+  let epoch_loss_limit_mid = 8.0 in
+  let epoch_loss_limit_last = 7.0 in
+  for epoch = 0 to epochs - 1 do
+    let epoch_loss = ref 0. in
+    for batch = 0 to n_batches - 1 do
+      let offset = batch * batch_size in
+      Tn.set_values input_batch.value
+        (seqs_to_flat_one_hot ~batch_size ~eff_seq_len train_inputs_arr ~offset);
+      Tn.set_values target_batch.value
+        (seqs_to_flat_one_hot ~batch_size ~eff_seq_len train_targets_arr ~offset);
+      let ctx' = Context.run ctx sgd_step in
+      ignore (ctx' : Context.t);
+      epoch_loss := !epoch_loss +. batch_loss.@[0];
+      Int.incr step_ref
+    done;
+    if epoch = 0 || epoch = epochs / 2 || epoch = epochs - 1 then (
+      let limit =
+        if epoch = 0 then epoch_loss_limit_first
+        else if epoch = epochs / 2 then epoch_loss_limit_mid
+        else epoch_loss_limit_last
+      in
+      printf "Epoch %d, loss below threshold=%b\n%!" epoch Float.(!epoch_loss < limit))
+  done;
+
+  (* === Held-out Evaluation (inference only, no gradient update) ===
+     We evaluate "valid transition accuracy": whether the argmax-predicted state is
+     one of the two valid successors for the current state.  This tests whether the
+     model learned the FSM transition function (which two states are reachable from
+     each state).  The binary input bit is intentionally unobserved, so exact-match
+     prediction of the specific successor caps at ~50%, but a model that learned
+     the transition relation achieves ~100% valid-transition accuracy.
+     Random baseline: 2/8 = 25%.  Threshold: >= 90%. *)
+  Tn.set_values infer_input.value
+    (seqs_to_flat_one_hot ~batch_size:num_test_seqs ~eff_seq_len test_inputs_arr ~offset:0);
+  let _ctx = Context.run ctx infer_routine in
+
+  let correct = ref 0 in
+  let total = num_test_seqs * eff_seq_len in
+  for seq = 0 to num_test_seqs - 1 do
+    for t = 0 to eff_seq_len - 1 do
+      let predicted = ref 0 in
+      let max_logit = ref Float.neg_infinity in
+      for s = 0 to num_states - 1 do
+        let logit = infer_logits.@{[| seq; t; s |]} in
+        if Float.(logit > !max_logit) then (
+          max_logit := logit;
+          predicted := s)
+      done;
+      let current = test_inputs_arr.(seq).(t) in
+      if !predicted = transition.(current).(0) || !predicted = transition.(current).(1) then
+        Int.incr correct
+    done
+  done;
+  let accuracy = Float.of_int !correct /. Float.of_int total in
+  printf "Held-out valid-transition accuracy above 0.90=%b\n%!" Float.(accuracy >= 0.90)


### PR DESCRIPTION
## Summary

- Use library `decoder_only_block` in `layer_norm_test.ml` (replaces local `mini_decoder_block` duplicate)
- Update README.md v0.6.4 checklist: mark transformer example as done
- Update CHANGES.md with decoder_only blocks and transformer_names entries

The core implementation (`decoder_only_block`/`decoder_only` in `nn_blocks.ml`, `transformer_names.ml` training + generation, dune stanza, expected output) was added in prior commits on this branch.

Closes #57

## Test plan

- [x] `dune build @check` passes
- [x] `dune runtest test/operations/` — `layer_norm_test` output matches `.expected`
- [x] `dune runtest test/training/` — `transformer_names` output matches `.expected`
- [x] `OCANNL_BACKEND=sync_cc dune exec test/training/transformer_names.exe` runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)