### PR TITLE
Remove deprecated multi-streaming infrastructure (#341)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changed
+
+- Removed deprecated multi-streaming infrastructure (#341). Each device now has a single execution context. Removed `config` type, `suggested_num_streams`, `Streaming_for`, `sharing` type (`Per_stream`/`Shared_cross_streams`), cross-stream synchronization logic, and `round_robin`/`round_robin_dry_run` training helpers.
+
 ### Added
 
 - Axis concatenation/block tensor support in einsum notation (`a^b` syntax)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [ROADMAP.md](ROADMAP.md) for the detailed schedule. Target: **v0.9 at ICFP 2
   - [ ] RoPE embeddings.
   - [ ] Transformer for the Names dataset (bigram MLP exists, not full transformer).
 * **0.7.0 (End Feb 2026): Frontend finalization.** Paper-ready release for workshop submissions (OCaml Workshop, FProPer).
-  - [ ] Cleanup of deprecated streams functionality.
+  - [x] Cleanup of deprecated streams functionality.
   - [ ] Migrating from the "hosted tensor" idea to always requiring a context when accessing tensors and dealing with devices directly.
   - [ ] Tensor saving, loading, and restoring.
 * **0.7.1 (Mid-Mar 2026): Real world examples.**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,8 +71,8 @@ This is the "paper-ready" release with mature frontend API.
   - Get rid of `array` field of `Tnode.t`
   - Remove or minimize `Ndarray` module
 
-- **Deprecated streams cleanup**
-  - Remove legacy streams functionality
+- **Deprecated streams cleanup** (done)
+  - Removed multi-streaming infrastructure; each device now has a single execution context
 
 - **Tensor persistence** (#373)
   - Tensor saving, loading, and restoring

--- a/arrayjit/lib/backend_impl.ml
+++ b/arrayjit/lib/backend_impl.ml
@@ -134,26 +134,26 @@ struct
       dev;
       ordinal;
       device_id;
-      cross_stream_candidates = Hashtbl.create (module Tnode);
-      owner_stream = Hashtbl.create (module Tnode);
-      shared_writer_streams = Hashtbl.create (module Tnode);
-      host_reading_streams = Hashtbl.create (module Tnode);
-      host_writing_streams = Hashtbl.create (module Tnode);
-      streams = Utils.weak_create ();
+      device_buffer_cache = Hashtbl.create (module Tnode);
+      current_stream = None;
+      next_stream_id = 0;
     }
 
   let make_stream device runner =
-    Utils.register_new device.streams ~grow_by:8 (fun stream_id ->
-        {
-          device;
-          runner;
-          merge_buffer = ref None;
-          stream_id;
-          allocated_buffer = None;
-          updating_for = Hashtbl.create (module Tnode);
-          updating_for_merge_buffer = None;
-          reader_streams = Hashtbl.create (module Tnode);
-        })
+    let stream_id = device.next_stream_id in
+    device.next_stream_id <- stream_id + 1;
+    let stream =
+      {
+        device;
+        runner;
+        merge_buffer = ref None;
+        stream_id;
+        allocated_buffer = None;
+        merge_buffer_node = ref None;
+      }
+    in
+    device.current_stream <- Some stream;
+    stream
 
   let get_name stream = [%string "%{name}:%{stream.device.ordinal#Int}:%{stream.stream_id#Int}"]
 
@@ -188,7 +188,6 @@ end
 *)
 module type For_add_scheduler = sig
   val name : string
-  val config : config
 
   include No_device_buffer_and_copying
 end

--- a/arrayjit/lib/backend_intf.ml
+++ b/arrayjit/lib/backend_intf.ml
@@ -36,10 +36,10 @@ end
 
 type merge_buffer_use = No | Copy [@@deriving sexp_of]
 
-type kparam_source =
+type param_source =
   | Log_file_name
   | Merge_buffer
-  | Kparam_ptr of Tnode.t
+  | Param_ptr of Tnode.t
   | Static_idx of Indexing.static_symbol
 [@@deriving sexp_of]
 

--- a/arrayjit/lib/backend_intf.ml
+++ b/arrayjit/lib/backend_intf.ml
@@ -34,17 +34,12 @@ module type Alloc_buffer = sig
   val free_buffer : (stream -> buffer_ptr -> unit) option
 end
 
-(** For now, we only configure a backend with regard to how many streams it should suggest using
-    (where applicable). *)
-type config = Only_devices_parallel | For_parallel_copying | Most_parallel_streams
-[@@deriving equal, sexp, variants]
+type merge_buffer_use = No | Copy [@@deriving sexp_of]
 
-type merge_buffer_use = No | Streaming_for of Task.t | Copy [@@deriving sexp_of]
-
-type param_source =
+type kparam_source =
   | Log_file_name
   | Merge_buffer
-  | Param_ptr of Tnode.t
+  | Kparam_ptr of Tnode.t
   | Static_idx of Indexing.static_symbol
 [@@deriving sexp_of]
 
@@ -92,15 +87,11 @@ type ('buffer_ptr, 'dev, 'runner, 'event) device_ref = {
   dev : 'dev;
   ordinal : int;
   device_id : int;
-  cross_stream_candidates : 'buffer_ptr Hashtbl.M(Tnode).t;
-  owner_stream : ('buffer_ptr, 'dev, 'runner, 'event) stream_ref Hashtbl.M(Tnode).t;
-  shared_writer_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
-  host_reading_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
-  host_writing_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
-  mutable streams : ('buffer_ptr, 'dev, 'runner, 'event) stream_ref Utils.weak_dynarray;
+  device_buffer_cache : 'buffer_ptr Hashtbl.M(Tnode).t;
+      (** Per-device buffer cache for reusing allocated arrays (e.g. read-only/constant nodes, or
+          host-backed buffers on unified memory systems). *)
+  mutable current_stream : ('buffer_ptr, 'dev, 'runner, 'event) stream_ref option;
+  mutable next_stream_id : int;
 }
 
 and ('buffer_ptr, 'dev, 'runner, 'event) stream_ref = {
@@ -109,10 +100,9 @@ and ('buffer_ptr, 'dev, 'runner, 'event) stream_ref = {
   merge_buffer : 'buffer_ptr buffer option ref;
   stream_id : int;
   mutable allocated_buffer : 'buffer_ptr buffer option;
-  updating_for : 'event Hashtbl.M(Tnode).t;
-  mutable updating_for_merge_buffer : (Tnode.t * 'event option) option;
-  reader_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
+  merge_buffer_node : Tnode.t option ref;
+      (** The tensor node currently occupying this stream's merge buffer, if any. Used for
+          consistency checking before routine execution. *)
 }
 
 let sexp_of_device_ref _ _ _ _ device = [%sexp_of: string * int] ("ordinal", device.ordinal)
@@ -120,64 +110,11 @@ let sexp_of_stream_ref _ _ _ _ stream = [%sexp_of: string * int] ("stream_id", s
 let equal_stream_ref s1 s2 = s1.stream_id = s2.stream_id && s1.device.ordinal = s2.device.ordinal
 
 type ('buffer_ptr, 'dev, 'runner, 'event) device =
-      ('buffer_ptr, 'dev, 'runner, 'event) device_ref = {
-  dev : 'dev;
-  ordinal : int;
-      (** The number of the represented backend's device, in the range from 0 to the number of the
-          backend's devices - 1. *)
-  device_id : int;
-      (** A unique identifier among all device instances of all backends. Note that multiple
-          [device_id] (distinct device instances) might refer to the same physical device. *)
-  cross_stream_candidates : 'buffer_ptr Hashtbl.M(Tnode).t;
-      (** Freshly created arrays that might be shared across streams. The map can both grow and
-          shrink. This map also contains buffer/pointer wrappers for hosted tnodes on unified memory
-          systems. *)
-  owner_stream : ('buffer_ptr, 'dev, 'runner, 'event) stream_ref Hashtbl.M(Tnode).t;
-      (** The stream owning a given node. This map can only grow. Currently, if the memory mode of a
-          node is inferred, only this stream will modify a cross-stream shared array. But memory
-          modes can also be set manually. *)
-  shared_writer_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams that most recently have been scheduled to update (write to) a
-          cross-stream-shared node, and the associated update completion event. The completed events
-          are removed opportunistically. *)
-  host_reading_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams that most recently have been reading from a node's on-host array. The
-          completed events are removed opportunistically. *)
-  host_writing_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams that most recently have been writing to a node's on-host array. The completed
-          events are removed opportunistically. *)
-  mutable streams : ('buffer_ptr, 'dev, 'runner, 'event) stream_ref Utils.weak_dynarray;
-      (** All (live) streams created on the device. Used by
-          {!With_buffer_retrieval_and_syncing.sync_device}. Warning: stream_id fields of garbage
-          collected streams can be reused! *)
-}
+  ('buffer_ptr, 'dev, 'runner, 'event) device_ref
 [@@deriving sexp_of]
 
 type ('buffer_ptr, 'dev, 'runner, 'event) stream =
-      ('buffer_ptr, 'dev, 'runner, 'event) stream_ref = {
-  device : ('buffer_ptr, 'dev, 'runner, 'event) device_ref;
-  runner : 'runner;
-  merge_buffer : 'buffer_ptr buffer option ref;
-      (** Depending on backend implementations, either the currently used merge buffer, or the one
-          most recently scheduled. Note that the pointer can be reused for nodes that fit in an
-          already allocated buffer. *)
-  stream_id : int;  (** An ID unique within the device for the lifetime of the stream. *)
-  mutable allocated_buffer : 'buffer_ptr buffer option;
-  updating_for : 'event Hashtbl.M(Tnode).t;
-  (* The completion event for the most recent updating (writing to) a node via this stream. *)
-  mutable updating_for_merge_buffer : (Tnode.t * 'event option) option;
-      (** The tensor node that was most recently scheduled to be in the [stream]'s merge buffer. The
-          event finishes after the [task] from a [Streaming_for task]. See also
-          {!field-updating_for}. *)
-  reader_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream_ref * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams, other than this stream, that most recently have been reading from a node in
-          this stream's context, and the associated use completion events. The completed events are
-          removed opportunistically. *)
-}
+  ('buffer_ptr, 'dev, 'runner, 'event) stream_ref
 [@@deriving sexp_of]
 
 let equal_stream = equal_stream_ref
@@ -297,11 +234,6 @@ module type Backend_device_common = sig
 
   val get_device : ordinal:int -> device
   val num_devices : unit -> int
-
-  val suggested_num_streams : device -> int
-  (** The optimal number of streams for the given device to follow the {!type:Backend_intf.config}
-      strategy. *)
-
   val new_stream : device -> stream
 end
 
@@ -334,14 +266,8 @@ module type With_buffer_retrieval_and_syncing = sig
       - If the node is absent from the [src] context and either it is present in the [dst] context
         or [into_merge_buffer] is different from [No]: raises an error.
       - If the node is absent from [dst] and [into_merge_buffer=No]: returns false.
-      - Schedules waiting for writing into the tensor node on [src] to finish, if any.
       - If [into_merge_buffer=No]: schedules a copy of the tensor node from [src] to [dst] and
         updates the writer event for the node.
-      - If [into_merge_buffer] is different from [No]: sets on [dst] the merge buffer source to the
-        given node.
-      - If [into_merge_buffer=Streaming_for task], remembers the buffer pointer of the source node
-        to use for streaming, runs [task] -- intended to be the routine making use of the merge
-        buffer, and initializes the merge buffer's streaming event.
       - If [into_merge_buffer=Copy], schedules copying from [src] to the merge buffer of [dst]'s
         stream, and updates the writer event for the merge buffer. *)
 
@@ -351,7 +277,7 @@ module type With_buffer_retrieval_and_syncing = sig
       and outputs the [dst] context with the tensor node. *)
 
   val sync_device : device -> unit
-  (** Synchronizes all the streams on a device, and cleans up (removes) all associated events. *)
+  (** Synchronizes the device's stream and cleans up merge buffer state. *)
 end
 
 module type Backend = sig

--- a/arrayjit/lib/backends.ml
+++ b/arrayjit/lib/backends.ml
@@ -88,6 +88,10 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
       match Map.find src.ctx_arrays tn with
       | None -> false
       | Some s_arr -> (
+          (* For cross-device copies, wait for the source stream's writes to complete
+             before the destination stream reads the data. *)
+          if not same_device then
+            Backend.will_wait_for dst (Backend.all_work src.stream);
           match into_merge_buffer with
           | No -> (
               match Map.find dst.ctx_arrays tn with
@@ -122,6 +126,9 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
                ("init_from_device: tensor node " ^ Tn.debug_name tn
               ^ " already on same stream, for stream " ^ Backend.get_name src.stream)
         else (
+          (* For cross-device copies, wait for source writes to complete. *)
+          if not same_device then
+            Backend.will_wait_for dst (Backend.all_work src.stream);
           match Map.find dst.ctx_arrays tn with
           | Some _ ->
               raise

--- a/arrayjit/lib/backends.ml
+++ b/arrayjit/lib/backends.ml
@@ -14,89 +14,48 @@ let _get_local_debug_runtime = Utils.get_local_debug_runtime
 
 let check_merge_buffer stream ~code_node =
   let name = function Some tn -> Tnode.debug_name tn | None -> "none" in
-  match (stream.updating_for_merge_buffer, code_node) with
+  match (!(stream.merge_buffer_node), code_node) with
   | _, None -> ()
-  | Some (actual, _), Some expected when Tnode.equal actual expected -> ()
+  | Some actual, Some expected when Tnode.equal actual expected -> ()
   | _ ->
       raise
       @@ Utils.User_error
            ("Merge buffer mismatch, on stream: "
-           ^ name (Option.map ~f:fst stream.updating_for_merge_buffer)
+           ^ name !(stream.merge_buffer_node)
            ^ ", expected by code: " ^ name code_node)
 
 module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncing) = struct
-  let wait_for_all ctx streams tn =
-    let s = ctx.stream in
-    Hashtbl.update_and_return streams tn
-      ~f:
-        (Fn.compose (List.filter ~f:(fun (_, e) -> not (Backend.is_done e)))
-        @@ Option.value ~default:[])
-    |> List.iter ~f:(fun (work_stream, e) ->
-        if not (equal_stream work_stream s) then Backend.will_wait_for ctx e)
-
-  let wait_for_ready ~dst ~src tn =
-    let s = src.stream in
-    let d = dst.stream in
-    (* TODO: maybe it's worthwhile to clean up s.updating_for every now and then. *)
-    Hashtbl.find s.updating_for tn
-    |> Option.iter ~f:(fun upd_e ->
-        if not (equal_stream s d || Backend.is_done upd_e) then Backend.will_wait_for dst upd_e)
-
   let%track3_sexp to_host (ctx : Backend.context) (tn : Tn.t) =
     match (tn, Map.find ctx.ctx_arrays tn) with
     | { Tn.array = (lazy (Some hosted)); _ }, Some src ->
-        if Tn.potentially_cross_stream tn then
-          wait_for_all ctx ctx.stream.device.shared_writer_streams tn;
         [%log "copying", Tn.debug_name tn, "at", (src : Backend.buffer_ptr), "to host"];
-        (* Stdio.printf "copying: %s to_host\n" (Tn.debug_name tn); *)
         Backend.to_host ~src_ptr:src ~src:ctx hosted;
-        let s = ctx.stream in
-        let e = Backend.all_work s in
-        Hashtbl.update s.device.host_writing_streams tn ~f:(fun l ->
-            (s, e) :: Option.value ~default:[] l);
         true
     | _ -> false
 
-  let update_writer_event ?e ?from ctx tn =
+  let update_writer_event ?e ctx tn =
     let s = ctx.stream in
     let e = Option.value_or_thunk e ~default:(fun () -> Backend.all_work s) in
-    let f l = (s, e) :: Option.value ~default:[] l in
-    (match (from, tn) with
-    | None, _ -> ()
-    | Some `Host, Assignments.(Node tn | Merge_buffer tn) ->
-        Hashtbl.update s.device.host_reading_streams tn ~f
-    | Some (`Src src), (Assignments.Node tn | Assignments.Merge_buffer tn) ->
-        Hashtbl.update src.reader_streams tn ~f);
-    (* Wait for writing to finish before reading. *)
-    (match (from, tn) with
-    | _, Assignments.Merge_buffer _ | Some `Host, _ -> ()
-    | _, Assignments.Node tn ->
+    (match tn with
+    | Assignments.Merge_buffer _ -> ()
+    | Assignments.Node tn ->
         Tnode.prepare_read
           ~is_done:(fun () -> Backend.is_done e)
           ~sync:(fun () -> Backend.sync e)
           ~transfer:(fun () -> if to_host ctx tn then Backend.await s)
           tn);
-    (* To be on the safe side, record events for potentially cross-stream nodes. *)
     match tn with
     | Node tn ->
-        if Tn.potentially_cross_stream tn then
-          Hashtbl.update s.device.shared_writer_streams tn ~f:(fun l ->
-              (s, e) :: Option.value ~default:[] l)
-        else Hashtbl.remove s.device.shared_writer_streams tn;
-        Hash_set.add tn.devices_not_lagging_host ctx.stream.device.device_id;
-        Hashtbl.update s.updating_for tn ~f:(fun _ -> e)
+        Hash_set.add tn.devices_not_lagging_host ctx.stream.device.device_id
     | Merge_buffer tn ->
-        (* Note: the previous event does not need to be done! *)
-        s.updating_for_merge_buffer <- Some (tn, Some e)
+        s.merge_buffer_node := Some tn
 
   let%track3_sexp from_host (ctx : Backend.context) tn =
     match (tn, Map.find ctx.ctx_arrays tn) with
     | { Tn.array = (lazy (Some hosted)); _ }, Some dst ->
-        wait_for_all ctx ctx.stream.reader_streams tn;
         [%log "copying", Tn.debug_name tn, "to", (dst : Backend.buffer_ptr), "from host"];
-        (* Stdio.printf "copying: %s from_host\n" (Tn.debug_name tn); *)
         Backend.from_host ~dst_ptr:dst ~dst:ctx hosted;
-        update_writer_event ~from:`Host ctx @@ Node tn;
+        update_writer_event ctx @@ Node tn;
         true
     | _ -> false
 
@@ -104,13 +63,10 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
     match (tn, Map.find ctx.ctx_arrays tn) with
     | { Tn.array = (lazy (Some hosted)); _ }, None ->
         let dims = Lazy.force tn.dims in
-        (* Use alloc_array since we're immediately copying from host *)
         let dst = Backend.alloc_array (Lazy.force tn.prec) ~dims ctx.stream in
-        wait_for_all ctx ctx.stream.reader_streams tn;
         [%log "copying", Tn.debug_name tn, "to", (dst : Backend.buffer_ptr), "from host"];
-        (* Stdio.printf "copying: %s from_host\n" (Tn.debug_name tn); *)
         Backend.from_host ~dst_ptr:dst ~dst:ctx hosted;
-        update_writer_event ~from:`Host ctx @@ Node tn;
+        update_writer_event ctx @@ Node tn;
         { ctx with ctx_arrays = Map.add_exn ctx.ctx_arrays ~key:tn ~data:dst }
     | _, Some _ ->
         raise
@@ -125,16 +81,13 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
 
   let%track3_sexp device_to_device (tn : Tn.t) ~into_merge_buffer ~(dst : Backend.context)
       ~(src : Backend.context) =
-    let ordinal_of ctx = ctx.stream.device.ordinal in
     let name_of ctx = Backend.(get_name ctx.stream) in
-    let same_device = ordinal_of dst = ordinal_of src in
-    if same_device && (Tn.known_shared_cross_streams tn || String.equal (name_of src) (name_of dst))
-    then false
+    let same_device = dst.stream.device.ordinal = src.stream.device.ordinal in
+    if same_device && String.equal (name_of src) (name_of dst) then false
     else
       match Map.find src.ctx_arrays tn with
       | None -> false
       | Some s_arr -> (
-          wait_for_ready ~dst ~src tn;
           match into_merge_buffer with
           | No -> (
               match Map.find dst.ctx_arrays tn with
@@ -143,27 +96,17 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
                   Backend.(
                     device_to_device tn ~into_merge_buffer ~dst_ptr:(Some d_arr) ~dst ~src_ptr:s_arr
                       ~src);
-                  update_writer_event ~from:(`Src src.stream) dst @@ Node tn;
+                  update_writer_event dst @@ Node tn;
                   [%log "copying", Tn.debug_name tn, "from", name_of src, "to", name_of dst];
                   true)
           | Copy ->
               Backend.(
                 device_to_device tn ~into_merge_buffer ~dst_ptr:None ~dst ~src_ptr:s_arr ~src);
-              update_writer_event ~from:(`Src src.stream) dst @@ Merge_buffer tn;
+              update_writer_event dst @@ Merge_buffer tn;
               [%log "copy into merge buffer", Tn.debug_name tn, "from", name_of src];
-              true
-          | Streaming_for task ->
-              Backend.(
-                device_to_device tn ~into_merge_buffer ~dst_ptr:None ~dst ~src_ptr:s_arr ~src);
-              dst.stream.updating_for_merge_buffer <- Some (tn, None);
-              let merge_task () = Task.run task in
-              merge_task ();
-              update_writer_event ~from:(`Src src.stream) dst @@ Merge_buffer tn;
-              [%log "streaming into merge buffer", Tn.debug_name tn, "from", name_of src];
               true)
 
   let%track3_sexp init_from_device (tn : Tn.t) ~(dst : Backend.context) ~(src : Backend.context) =
-    let ordinal_of ctx = ctx.stream.device.ordinal in
     let name_of ctx = Backend.(get_name ctx.stream) in
     match Map.find src.ctx_arrays tn with
     | None ->
@@ -172,18 +115,13 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
              ("init_from_device: tensor node " ^ Tn.debug_name tn ^ " is not in input context "
             ^ Backend.get_name src.stream ^ ", for stream " ^ Backend.get_name dst.stream)
     | Some s_arr ->
-        let same_device = ordinal_of dst = ordinal_of src in
-        if
-          same_device
-          && (Tn.known_shared_cross_streams tn || String.equal (name_of src) (name_of dst))
-        then
-          (* TODO: should we add s_arr to the output context? Failing now to be on the safe side. *)
+        let same_device = dst.stream.device.ordinal = src.stream.device.ordinal in
+        if same_device && String.equal (name_of src) (name_of dst) then
           raise
           @@ Utils.User_error
                ("init_from_device: tensor node " ^ Tn.debug_name tn
-              ^ " is shared across streams, for stream " ^ Backend.get_name src.stream)
+              ^ " already on same stream, for stream " ^ Backend.get_name src.stream)
         else (
-          wait_for_ready ~dst ~src tn;
           match Map.find dst.ctx_arrays tn with
           | Some _ ->
               raise
@@ -193,12 +131,11 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
                   ^ Backend.get_name src.stream)
           | None ->
               let dims = Lazy.force tn.dims in
-              (* Use alloc_array since we're immediately copying from another device *)
               let d_arr = Backend.alloc_array (Lazy.force tn.prec) ~dims dst.stream in
               Backend.(
                 device_to_device tn ~into_merge_buffer:No ~dst_ptr:(Some d_arr) ~dst ~src_ptr:s_arr
                   ~src);
-              update_writer_event ~from:(`Src src.stream) dst @@ Node tn;
+              update_writer_event dst @@ Node tn;
               [%log "copying", Tn.debug_name tn, "from", name_of src, "to", name_of dst];
               { dst with ctx_arrays = Map.add_exn dst.ctx_arrays ~key:tn ~data:d_arr })
 
@@ -212,16 +149,7 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
       if Utils.settings.automatic_host_transfers then
         Set.iter hosted_inputs ~f:(fun tn ->
             if not (Hash_set.mem tn.devices_not_lagging_host s.device.device_id) then
-              assert (from_host r.context tn));
-      Set.iter r.inputs ~f:(fun tn ->
-          if Tn.potentially_cross_stream tn then
-            Option.iter (Hashtbl.find s.device.shared_writer_streams tn) ~f:(fun data ->
-                let data = List.filter data ~f:(fun (_, e) -> not (Backend.is_done e)) in
-                Hashtbl.set s.device.shared_writer_streams ~key:tn ~data;
-                List.iter data ~f:(fun (work_stream, e) ->
-                    if not (equal_stream work_stream s) then Backend.will_wait_for r.context e))
-          else Hashtbl.remove s.device.shared_writer_streams tn)
-      (* Since merge buffers are always per-stream, no need to check r.merge_buffer_input. *)
+              assert (from_host r.context tn))
     in
     let post () =
       let e = Backend.all_work s in
@@ -235,14 +163,9 @@ module Add_buffer_retrieval_and_syncing (Backend : No_buffer_retrieval_or_syncin
     { r with schedule = Task.(prepend ~work:pre @@ append ~work:post r.schedule) }
 
   let sync_device device =
-    Utils.weak_iter device.streams ~f:Backend.await;
-    Hashtbl.clear device.host_writing_streams;
-    Hashtbl.clear device.host_reading_streams;
-    Hashtbl.clear device.shared_writer_streams;
-    Utils.weak_iter device.streams ~f:(fun s ->
-        Hashtbl.clear s.reader_streams;
-        s.updating_for_merge_buffer <- None;
-        Hashtbl.clear s.updating_for)
+    Option.iter device.current_stream ~f:(fun s ->
+        Backend.await s;
+        s.merge_buffer_node := None)
 end
 
 let%track6_sexp lower_assignments optim_ctx ?name bindings asgns =
@@ -302,16 +225,12 @@ module Add_device
         with type buffer_ptr = Impl.buffer_ptr
          and type optimize_ctx = Low_level.optimize_ctx)
     (Backend : Lowered_no_device_backend)
-    (Config : sig
-      val config : config
-    end)
 (* : Lowered_backend *) =
 struct
   include Backend
 
   include Add_scheduler (struct
     include Backend
-    include Config
   end)
 
   type code = { lowered : Low_level.optimized; proc : Backend.procedure } [@@deriving sexp_of]
@@ -379,7 +298,6 @@ struct
       match (into_merge_buffer, dst_ptr) with
       | No, None -> invalid_arg "Multicore_scheduler.device_to_device: missing dst_ptr"
       | No, Some dst_ptr -> fun () -> buffer_to_buffer ~dst:dst_ptr ~src:src_ptr ~size_in_bytes
-      | Streaming_for _, _ -> fun () -> s.merge_buffer := Some { ptr = src_ptr; size_in_bytes }
       | Copy, _ ->
           fun () ->
             let allocated_capacity =
@@ -474,9 +392,6 @@ module Raise_backend (Device : Lowered_backend) : Backend = struct
       [%log (key : Tnode.t)];
       let default () =
         let dims = Lazy.force key.dims in
-        (* Use alloc_array when zero initialization is not needed: - When copying from host
-           immediately after allocation - When the node has explicit Zero_out operations in the
-           lowered code *)
         let will_copy_from_host =
           Utils.settings.automatic_host_transfers && Tn.known_constant key
           && match key.array with (lazy (Some _)) -> true | _ -> false
@@ -506,57 +421,29 @@ module Raise_backend (Device : Lowered_backend) : Backend = struct
           [%log "Backends.alloc_if_needed: failed to add old node to context", (key : Tnode.t)];
           raise exn
       in
-      let hash_find_exn ~message:_msg tbl =
-        try Hashtbl.find_exn tbl key
-        with exn ->
-          [%log
-            "Backends.alloc_if_needed: failed to find node in hash table", _msg, (key : Tnode.t)];
-          raise exn
-      in
       let device = stream.device in
-      (* It's the user's responsibility to ensure that constants are initialized on devices, the
-         user can choose to run initialization code on multiple streams redundantly, or on the owner
-         stream only and then to use init_from_device. *)
       if node.Low_level.read_only || Tn.known_constant key then (
         if not node.Low_level.read_only then
           [%log "Backends.alloc_if_needed: constant node is not read-only", (key : Tnode.t)];
-        if Tn.known_non_cross_stream key then add_new_exn ()
-        else
-          let read_only_buffer : Device.buffer_ptr =
-            match use_host_memory with
-            | None -> Hashtbl.find_or_add device.cross_stream_candidates key ~default
-            | Some get_buffer_ptr ->
-                if
-                  (not (Hashtbl.mem device.cross_stream_candidates key))
-                  && Tn.known_shared_cross_streams key && Tn.is_hosted_force key 44
-                then
-                  Hashtbl.update_and_return device.cross_stream_candidates key ~f:(fun _ ->
-                      get_buffer_ptr ~size_in_bytes:(Lazy.force key.size_in_bytes)
-                      @@ Ndarray.get_voidptr_not_managed
-                      @@ Option.value_exn ~here:[%here]
-                      @@ Lazy.force key.array)
-                else Hashtbl.find_or_add device.cross_stream_candidates key ~default
-          in
-          if Hashtbl.mem device.cross_stream_candidates key then
-            Tn.update_memory_sharing key Tn.Shared_cross_streams 39;
-          add_old_exn read_only_buffer)
-      else if Tn.known_shared_cross_streams key then (
-        if Hashtbl.mem device.owner_stream key then (
-          if not (equal_stream stream (hash_find_exn ~message:"owner_stream" device.owner_stream))
-          then
-            raise
-            @@ Utils.User_error
-                 ("Backends.alloc_if_needed: node " ^ Tn.debug_name key
-                ^ " assumed to be cross-stream-shared but then written to on multiple devices"))
-        else Hashtbl.add_exn device.owner_stream ~key ~data:stream;
-        let shared_buffer : Device.buffer_ptr =
-          hash_find_exn ~message:"cross_stream_candidates" device.cross_stream_candidates
+        (* Use per-device buffer cache for read-only/constant nodes *)
+        let cached_buffer : Device.buffer_ptr =
+          match use_host_memory with
+          | None -> Hashtbl.find_or_add device.device_buffer_cache key ~default
+          | Some get_buffer_ptr ->
+              if
+                (not (Hashtbl.mem device.device_buffer_cache key))
+                && Tn.is_hosted_force key 44
+              then
+                Hashtbl.update_and_return device.device_buffer_cache key ~f:(fun _ ->
+                    get_buffer_ptr ~size_in_bytes:(Lazy.force key.size_in_bytes)
+                    @@ Ndarray.get_voidptr_not_managed
+                    @@ Option.value_exn ~here:[%here]
+                    @@ Lazy.force key.array)
+              else Hashtbl.find_or_add device.device_buffer_cache key ~default
         in
-        add_old_exn shared_buffer)
-      else (
-        Tn.update_memory_sharing key Tn.Per_stream 410;
-        Hashtbl.remove device.cross_stream_candidates key;
-        add_new_exn ()))
+        add_old_exn cached_buffer)
+      else
+        add_new_exn ())
     else ctx_arrays
 
   let%debug3_sexp link context (code : code) =
@@ -614,12 +501,9 @@ module Make_device_backend_from_lowered
       With_scheduler
         with type buffer_ptr = Impl.buffer_ptr
          and type optimize_ctx = Low_level.optimize_ctx)
-    (Backend_impl : Lowered_no_device_backend)
-    (Config : sig
-      val config : config
-    end) =
+    (Backend_impl : Lowered_no_device_backend) =
 struct
-  module Lowered_device = Add_device (Add_scheduler) (Backend_impl) (Config)
+  module Lowered_device = Add_device (Add_scheduler) (Backend_impl)
   module Backend_device = Raise_backend (Lowered_device)
   include Backend_device
 end
@@ -637,29 +521,23 @@ let finalize (type buffer_ptr dev runner event optimize_ctx)
         Map.iteri ctx.ctx_arrays ~f:(fun ~key ~data ->
             if
               (not (Option.exists ctx.parent ~f:(fun pc -> Map.mem pc.ctx_arrays key)))
-              && not (Hashtbl.mem ctx.stream.device.cross_stream_candidates key)
+              && not (Hashtbl.mem ctx.stream.device.device_buffer_cache key)
             then mem_free ctx.stream data)))
 
-let%track5_sexp fresh_backend ?backend_name ?(config = For_parallel_copying) () =
+let%track5_sexp fresh_backend ?backend_name () =
   Stdlib.Gc.full_major ();
-  (* TODO: is running again needed to give time to weak arrays to become empty? *)
   Stdlib.Gc.full_major ();
   (* Note: we invoke functors from within fresh_backend to fully isolate backends from distinct
      calls to fresh_backend. *)
-  let module Config = struct
-    let config = config
-  end in
   match
     Option.value_or_thunk backend_name ~default:(fun () ->
         Utils.get_global_arg ~arg_name:"backend" ~default:"multicore_cc")
     |> String.lowercase
   with
   | "multicore_cc" ->
-      (module Make_device_backend_from_lowered (Schedulers.Multicore) (Cc_backend) (Config)
-      : Backend)
+      (module Make_device_backend_from_lowered (Schedulers.Multicore) (Cc_backend) : Backend)
   | "sync_cc" ->
-      (module Make_device_backend_from_lowered (Schedulers.Sync) (Cc_backend) (Config) : Backend)
-  | "cuda" -> (module Raise_backend (Cuda_backend_impl.Fresh (Config) : Lowered_backend) : Backend)
-  | "metal" ->
-      (module Raise_backend (Metal_backend_impl.Fresh (Config) : Lowered_backend) : Backend)
+      (module Make_device_backend_from_lowered (Schedulers.Sync) (Cc_backend) : Backend)
+  | "cuda" -> (module Raise_backend (Cuda_backend_impl.Fresh : Lowered_backend) : Backend)
+  | "metal" -> (module Raise_backend (Metal_backend_impl.Fresh : Lowered_backend) : Backend)
   | backend -> invalid_arg [%string "Backends.fresh_backend: unknown backend %{backend}"]

--- a/arrayjit/lib/backends.mli
+++ b/arrayjit/lib/backends.mli
@@ -22,8 +22,7 @@ val finalize :
 
     Note: this type will get simpler with modular explicits. *)
 
-val fresh_backend :
-  ?backend_name:string -> ?config:Ir.Backend_intf.config -> unit -> (module Ir.Backend_intf.Backend)
+val fresh_backend : ?backend_name:string -> unit -> (module Ir.Backend_intf.Backend)
 (** Creates a new backend corresponding to [backend_name], or if omitted, selected via the global
     [backend] setting. It should be safe to reinitialize the tensor system before [fresh_backend].
 *)

--- a/arrayjit/lib/cuda_backend.ml
+++ b/arrayjit/lib/cuda_backend.ml
@@ -284,7 +284,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
   type code = {
     traced_store : Low_level.traced_store;
     ptx : Nvrtc.compile_to_ptx_result;
-    kparams : (string * kparam_source) list;
+    params : (string * param_source) list;
     bindings : Indexing.unit_bindings;
     name : string;
   }
@@ -294,7 +294,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
     traced_stores : Low_level.traced_store option array;
     ptx : Nvrtc.compile_to_ptx_result;
     bindings : Indexing.unit_bindings;
-    kparams_and_names : ((string * kparam_source) list * string) option array;
+    params_and_names : ((string * param_source) list * string) option array;
   }
   [@@deriving sexp_of]
 
@@ -839,7 +839,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
       let procs = [| lowered |]
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
-    let kparams, proc_doc = Syntax.compile_proc ~name idx_params lowered in
+    let params, proc_doc = Syntax.compile_proc ~name idx_params lowered in
     let cuda_includes =
       {|#include <cuda_fp16.h>
 #include <cuda_bf16.h>
@@ -861,21 +861,21 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
         ~proc_doc
     in
     let ptx = cuda_to_ptx ~name source in
-    { traced_store; ptx; kparams; bindings; name }
+    { traced_store; ptx; params; bindings; name }
 
   let%diagn2_sexp compile_batch ~names bindings lowereds =
     let module Syntax = C_syntax.C_syntax (Cuda_syntax_config (struct
       let procs = Array.filter_opt lowereds
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
-    let kparams_and_docs =
+    let params_and_docs =
       Array.map2_exn names lowereds
         ~f:
           (Option.map2 ~f:(fun name lowered ->
-               let kparams, doc = Syntax.compile_proc ~name idx_params lowered in
-               ((kparams, name), doc)))
+               let params, doc = Syntax.compile_proc ~name idx_params lowered in
+               ((params, name), doc)))
     in
-    let all_proc_docs = List.filter_map (Array.to_list kparams_and_docs) ~f:(Option.map ~f:snd) in
+    let all_proc_docs = List.filter_map (Array.to_list params_and_docs) ~f:(Option.map ~f:snd) in
     let final_doc = PPrint.(separate hardline all_proc_docs) in
     let cuda_includes =
       {|#include <cuda_fp16.h>
@@ -905,8 +905,8 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
     in
     let ptx = cuda_to_ptx ~name source in
     let traced_stores = Array.map lowereds ~f:(Option.map ~f:(fun l -> l.Low_level.traced_store)) in
-    let kparams_and_names = Array.map kparams_and_docs ~f:(Option.map ~f:fst) in
-    { traced_stores; ptx; kparams_and_names; bindings }
+    let params_and_names = Array.map params_and_docs ~f:(Option.map ~f:fst) in
+    { traced_stores; ptx; params_and_names; bindings }
 
   let get_global_run_id =
     let next_id = ref 0 in
@@ -915,7 +915,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
       if !next_id < 0 then next_id := 0;
       !next_id
 
-  let link_proc ~prior_context ~name ~(kparams : (string * kparam_source) list) ~ctx_arrays
+  let link_proc ~prior_context ~name ~(params : (string * param_source) list) ~ctx_arrays
       lowered_bindings run_module =
     let func = Cu.Module.get_function run_module ~name in
     let stream = prior_context.stream in
@@ -929,13 +929,13 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
         "on",
         stream_name,
         (log_id : int),
-        (kparams : (string * kparam_source) list)];
+        (params : (string * param_source) list)];
       let module S = Cu.Stream in
       let args : S.kernel_param list =
         (* TODO: should we prohibit or warn about local-only tensors that are in
            prior_context.ctx_arrays? *)
-        List.map kparams ~f:(function
-          | _name, Kparam_ptr tn ->
+        List.map params ~f:(function
+          | _name, Param_ptr tn ->
               let arr = Option.value_exn ~here:[%here] @@ Map.find ctx_arrays tn in
               S.Tensor arr
           | _name, Log_file_name -> S.Int log_id
@@ -985,7 +985,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
       List.map idx_params ~f:(fun s -> (s, ref 0))
     in
     let task =
-      link_proc ~prior_context ~name:code.name ~kparams:code.kparams ~ctx_arrays lowered_bindings
+      link_proc ~prior_context ~name:code.name ~params:code.params ~ctx_arrays lowered_bindings
         run_module
     in
     (lowered_bindings, task)
@@ -1000,11 +1000,11 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
     let run_module = Cu.Module.load_data_ex code_batch.ptx (run_options ()) in
     prior_context.stream.device.dev.set_builtins_in run_module;
     let procs =
-      Array.mapi code_batch.kparams_and_names ~f:(fun i pns ->
+      Array.mapi code_batch.params_and_names ~f:(fun i pns ->
           Option.value ~default:None
-          @@ Option.map2 pns ctx_arrays.(i) ~f:(fun (kparams, name) ctx_arrays ->
+          @@ Option.map2 pns ctx_arrays.(i) ~f:(fun (params, name) ctx_arrays ->
               let task =
-                link_proc ~prior_context ~name ~kparams ~ctx_arrays lowered_bindings run_module
+                link_proc ~prior_context ~name ~params ~ctx_arrays lowered_bindings run_module
               in
               Some task))
     in

--- a/arrayjit/lib/cuda_backend.ml
+++ b/arrayjit/lib/cuda_backend.ml
@@ -91,9 +91,7 @@ end
 let initialized_devices = Hash_set.create (module Int)
 let initialized = ref false
 
-module Fresh (Config : sig
-  val config : Ir.Backend_intf.config
-end) : Ir.Backend_impl.Lowered_backend = struct
+module Fresh : Ir.Backend_impl.Lowered_backend = struct
   include Backend_impl.Device (Device_stream) (Alloc_buffer)
 
   let use_host_memory = None
@@ -131,7 +129,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     Cu.Context.set_current device.dev.primary_context;
     Cu.Context.synchronize ();
     (* Note: this is not necessary as releasing the primary context by GC will reset the context. *)
-    Hashtbl.iter device.cross_stream_candidates ~f:(fun buffer_ptr ->
+    Hashtbl.iter device.device_buffer_cache ~f:(fun buffer_ptr ->
         Cu.Deviceptr.mem_free buffer_ptr)
 
   let%diagn2_sexp cuda_to_ptx ~name cu_src =
@@ -243,12 +241,6 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     in
     get_props
 
-  let suggested_num_streams device =
-    match Config.config with
-    | Only_devices_parallel -> 1
-    | For_parallel_copying -> 1 + (cuda_properties device).async_engine_count
-    | Most_parallel_streams -> (cuda_properties device).multiprocessor_count
-
   let await stream : unit =
     set_ctx stream.device.dev.primary_context;
     Cu.Stream.synchronize stream.runner
@@ -283,9 +275,6 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     | No, Some dst_ptr ->
         set_ctx @@ ctx_of dst;
         memcpy ~dst_ptr
-    | Streaming_for _, _ ->
-        assert same_device;
-        dst.stream.merge_buffer := Some { ptr = src_ptr; size_in_bytes }
     | Copy, _ ->
         set_ctx @@ ctx_of dst;
         opt_alloc_merge_buffer ~size_in_bytes dev.dev dst.stream;
@@ -295,7 +284,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
   type code = {
     traced_store : Low_level.traced_store;
     ptx : Nvrtc.compile_to_ptx_result;
-    params : (string * param_source) list;
+    kparams : (string * kparam_source) list;
     bindings : Indexing.unit_bindings;
     name : string;
   }
@@ -305,7 +294,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     traced_stores : Low_level.traced_store option array;
     ptx : Nvrtc.compile_to_ptx_result;
     bindings : Indexing.unit_bindings;
-    params_and_names : ((string * param_source) list * string) option array;
+    kparams_and_names : ((string * kparam_source) list * string) option array;
   }
   [@@deriving sexp_of]
 
@@ -850,7 +839,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
       let procs = [| lowered |]
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
-    let params, proc_doc = Syntax.compile_proc ~name idx_params lowered in
+    let kparams, proc_doc = Syntax.compile_proc ~name idx_params lowered in
     let cuda_includes =
       {|#include <cuda_fp16.h>
 #include <cuda_bf16.h>
@@ -872,21 +861,21 @@ end) : Ir.Backend_impl.Lowered_backend = struct
         ~proc_doc
     in
     let ptx = cuda_to_ptx ~name source in
-    { traced_store; ptx; params; bindings; name }
+    { traced_store; ptx; kparams; bindings; name }
 
   let%diagn2_sexp compile_batch ~names bindings lowereds =
     let module Syntax = C_syntax.C_syntax (Cuda_syntax_config (struct
       let procs = Array.filter_opt lowereds
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
-    let params_and_docs =
+    let kparams_and_docs =
       Array.map2_exn names lowereds
         ~f:
           (Option.map2 ~f:(fun name lowered ->
-               let params, doc = Syntax.compile_proc ~name idx_params lowered in
-               ((params, name), doc)))
+               let kparams, doc = Syntax.compile_proc ~name idx_params lowered in
+               ((kparams, name), doc)))
     in
-    let all_proc_docs = List.filter_map (Array.to_list params_and_docs) ~f:(Option.map ~f:snd) in
+    let all_proc_docs = List.filter_map (Array.to_list kparams_and_docs) ~f:(Option.map ~f:snd) in
     let final_doc = PPrint.(separate hardline all_proc_docs) in
     let cuda_includes =
       {|#include <cuda_fp16.h>
@@ -916,8 +905,8 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     in
     let ptx = cuda_to_ptx ~name source in
     let traced_stores = Array.map lowereds ~f:(Option.map ~f:(fun l -> l.Low_level.traced_store)) in
-    let params_and_names = Array.map params_and_docs ~f:(Option.map ~f:fst) in
-    { traced_stores; ptx; params_and_names; bindings }
+    let kparams_and_names = Array.map kparams_and_docs ~f:(Option.map ~f:fst) in
+    { traced_stores; ptx; kparams_and_names; bindings }
 
   let get_global_run_id =
     let next_id = ref 0 in
@@ -926,7 +915,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
       if !next_id < 0 then next_id := 0;
       !next_id
 
-  let link_proc ~prior_context ~name ~(params : (string * param_source) list) ~ctx_arrays
+  let link_proc ~prior_context ~name ~(kparams : (string * kparam_source) list) ~ctx_arrays
       lowered_bindings run_module =
     let func = Cu.Module.get_function run_module ~name in
     let stream = prior_context.stream in
@@ -940,13 +929,13 @@ end) : Ir.Backend_impl.Lowered_backend = struct
         "on",
         stream_name,
         (log_id : int),
-        (params : (string * param_source) list)];
+        (kparams : (string * kparam_source) list)];
       let module S = Cu.Stream in
       let args : S.kernel_param list =
         (* TODO: should we prohibit or warn about local-only tensors that are in
            prior_context.ctx_arrays? *)
-        List.map params ~f:(function
-          | _name, Param_ptr tn ->
+        List.map kparams ~f:(function
+          | _name, Kparam_ptr tn ->
               let arr = Option.value_exn ~here:[%here] @@ Map.find ctx_arrays tn in
               S.Tensor arr
           | _name, Log_file_name -> S.Int log_id
@@ -996,7 +985,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
       List.map idx_params ~f:(fun s -> (s, ref 0))
     in
     let task =
-      link_proc ~prior_context ~name:code.name ~params:code.params ~ctx_arrays lowered_bindings
+      link_proc ~prior_context ~name:code.name ~kparams:code.kparams ~ctx_arrays lowered_bindings
         run_module
     in
     (lowered_bindings, task)
@@ -1011,11 +1000,11 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     let run_module = Cu.Module.load_data_ex code_batch.ptx (run_options ()) in
     prior_context.stream.device.dev.set_builtins_in run_module;
     let procs =
-      Array.mapi code_batch.params_and_names ~f:(fun i pns ->
+      Array.mapi code_batch.kparams_and_names ~f:(fun i pns ->
           Option.value ~default:None
-          @@ Option.map2 pns ctx_arrays.(i) ~f:(fun (params, name) ctx_arrays ->
+          @@ Option.map2 pns ctx_arrays.(i) ~f:(fun (kparams, name) ctx_arrays ->
               let task =
-                link_proc ~prior_context ~name ~params ~ctx_arrays lowered_bindings run_module
+                link_proc ~prior_context ~name ~kparams ~ctx_arrays lowered_bindings run_module
               in
               Some task))
     in

--- a/arrayjit/lib/cuda_backend.mli
+++ b/arrayjit/lib/cuda_backend.mli
@@ -1,3 +1,1 @@
-module Fresh (_ : sig
-  val config : Ir.Backend_intf.config
-end) : Ir.Backend_impl.Lowered_backend
+module Fresh : Ir.Backend_impl.Lowered_backend

--- a/arrayjit/lib/cuda_backend_impl.missing.ml
+++ b/arrayjit/lib/cuda_backend_impl.missing.ml
@@ -1,9 +1,5 @@
-module Fresh (Config : sig
-  val config : Ir.Backend_intf.config
-end) =
+module Fresh =
 struct
-  let _ = ignore Config.config
-
   include Lowered_backend_missing.Missing (struct
     let name = "cuda"
   end)

--- a/arrayjit/lib/cuda_backend_impl.mli
+++ b/arrayjit/lib/cuda_backend_impl.mli
@@ -1,3 +1,1 @@
-module Fresh (_ : sig
-  val config : Ir.Backend_intf.config
-end) : Ir.Backend_impl.Lowered_backend
+module Fresh : Ir.Backend_impl.Lowered_backend

--- a/arrayjit/lib/metal_backend.ml
+++ b/arrayjit/lib/metal_backend.ml
@@ -387,7 +387,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
     metal_source : string; (* Store source, compile during link if not already compiled *)
     compiled_code : Me.Library.t option array; (* Store compiled code per device *)
     func_name : string;
-    kparams : (string * kparam_source) list;
+    params : (string * param_source) list;
     bindings : Indexing.unit_bindings;
     traced_store : Low_level.traced_store;
   }
@@ -396,7 +396,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
   type code_batch = {
     metal_source : string; (* Store combined source *)
     compiled_code : Me.Library.t option array; (* Store compiled code per device *)
-    funcs : (string * (string * kparam_source) list) option array; (* func_name * kparams *)
+    funcs : (string * (string * param_source) list) option array; (* func_name * params *)
     bindings : Indexing.unit_bindings;
     traced_stores : Low_level.traced_store option array;
   }
@@ -671,7 +671,7 @@ module Fresh : Ir.Backend_impl.Lowered_backend = struct
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
     (* Add Metal address space qualifiers *)
-    let kparams, proc_doc = Syntax.compile_proc ~name idx_params lowered in
+    let params, proc_doc = Syntax.compile_proc ~name idx_params lowered in
     let metal_includes = {|#include <metal_stdlib>
 using namespace metal;|} in
     let source =
@@ -683,7 +683,7 @@ using namespace metal;|} in
       compiled_code = Array.create ~len:num_devs None;
       (* One slot per device *)
       func_name = name;
-      kparams;
+      params;
       bindings;
       traced_store = lowered.traced_store;
     }
@@ -697,8 +697,8 @@ using namespace metal;|} in
       Array.map2_exn names lowereds
         ~f:
           (Option.map2 ~f:(fun name lowered ->
-               let kparams, doc = Syntax.compile_proc ~name idx_params lowered in
-               ((name, kparams), doc)))
+               let params, doc = Syntax.compile_proc ~name idx_params lowered in
+               ((name, params), doc)))
     in
     let all_proc_docs = List.filter_map (Array.to_list funcs_and_docs) ~f:(Option.map ~f:snd) in
     let final_doc = PPrint.(separate hardline all_proc_docs) in
@@ -720,7 +720,7 @@ using namespace metal;|} in
     }
 
   let%debug4_sexp link_proc ~prior_context ~library ~func_name
-      ~(kparams : (string * kparam_source) list) ~lowered_bindings ~(ctx_arrays : buffer_ptr Tn.t_map)
+      ~(params : (string * param_source) list) ~lowered_bindings ~(ctx_arrays : buffer_ptr Tn.t_map)
       : Task.t =
     let stream = prior_context.stream in
     let device = stream.device.dev in
@@ -740,12 +740,12 @@ using namespace metal;|} in
         Me.ComputeCommandEncoder.set_compute_pipeline_state encoder pso;
 
         (* Set arguments *)
-        List.iteri kparams ~f:(fun index (_p_name, p_source) ->
+        List.iteri params ~f:(fun index (_p_name, p_source) ->
             match p_source with
-            | Kparam_ptr tn when Map.mem ctx_arrays tn ->
+            | Param_ptr tn when Map.mem ctx_arrays tn ->
                 let buffer = Map.find_exn ctx_arrays tn in
                 Me.ComputeCommandEncoder.set_buffer encoder ~index buffer
-            | Kparam_ptr tn when Tn.known_constant tn && Tn.is_hosted_force tn 48 ->
+            | Param_ptr tn when Tn.known_constant tn && Tn.is_hosted_force tn 48 ->
                 let buffer =
                   Hashtbl.find_or_add stream.device.device_buffer_cache tn ~default:(fun () ->
                       get_buffer_for_ptr device ~size_in_bytes:(Lazy.force tn.size_in_bytes)
@@ -754,9 +754,9 @@ using namespace metal;|} in
                       @@ Lazy.force tn.array)
                 in
                 Me.ComputeCommandEncoder.set_buffer encoder ~index buffer
-            | Kparam_ptr tn ->
+            | Param_ptr tn ->
                 failwith
-                  [%string "Kparam_ptr %{Tn.debug_name tn} not found in ctx_arrays for %{func_name}"]
+                  [%string "Param_ptr %{Tn.debug_name tn} not found in ctx_arrays for %{func_name}"]
             | Static_idx s ->
                 let value = !(Indexing.find_exn lowered_bindings s) in
                 let size = Ctypes.sizeof Ctypes.int in
@@ -803,7 +803,7 @@ using namespace metal;|} in
       List.map (Indexing.bound_symbols code.bindings) ~f:(fun s -> (s, ref 0))
     in
     let task =
-      link_proc ~prior_context ~library ~func_name:code.func_name ~kparams:code.kparams
+      link_proc ~prior_context ~library ~func_name:code.func_name ~params:code.params
         ~lowered_bindings ~ctx_arrays
     in
     (lowered_bindings, task)
@@ -817,9 +817,9 @@ using namespace metal;|} in
 
     let tasks =
       Array.mapi code_batch.funcs ~f:(fun i func_opt ->
-          Option.bind func_opt ~f:(fun (func_name, kparams) ->
+          Option.bind func_opt ~f:(fun (func_name, params) ->
               Option.map ctx_arrays_opts.(i) ~f:(fun ctx_arrays ->
-                  link_proc ~prior_context ~library ~func_name ~kparams ~lowered_bindings ~ctx_arrays)))
+                  link_proc ~prior_context ~library ~func_name ~params ~lowered_bindings ~ctx_arrays)))
     in
     (lowered_bindings, tasks)
 end

--- a/arrayjit/lib/metal_backend.ml
+++ b/arrayjit/lib/metal_backend.ml
@@ -110,9 +110,7 @@ module Alloc_buffer = struct
 end
 
 (* Functor defining the backend *)
-module Fresh (Config : sig
-  val config : Ir.Backend_intf.config
-end) : Ir.Backend_impl.Lowered_backend = struct
+module Fresh : Ir.Backend_impl.Lowered_backend = struct
   (* Include the device setup with types and allocation *)
   include Backend_impl.Device (Device_stream) (Alloc_buffer)
 
@@ -244,10 +242,6 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     Unsigned.ULLong.equal current_signaled expected_signaled
 
   (* --- Configuration and Info --- *)
-  let suggested_num_streams _device =
-    match Config.config with
-    | Only_devices_parallel | For_parallel_copying | Most_parallel_streams -> 1
-
   let get_used_memory _device = Atomic.get allocated_memory
 
   let static_properties =
@@ -367,8 +361,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     stream.merge_buffer :=
       Some (alloc_buffer ?old_buffer:!(stream.merge_buffer) ~size_in_bytes stream)
 
-  let device_to_device tn ~into_merge_buffer ~dst_ptr ~dst ~src_ptr ~src =
-    let same_device = dst.stream.device.ordinal = src.stream.device.ordinal in
+  let device_to_device tn ~into_merge_buffer ~dst_ptr ~dst ~src_ptr ~src:_ =
     let size_in_bytes = Lazy.force tn.Tn.size_in_bytes in
 
     let memcpy ~dst_ptr =
@@ -384,13 +377,6 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     match (into_merge_buffer, dst_ptr) with
     | No, None -> invalid_arg "Metal_backend.device_to_device: missing dst_ptr"
     | No, Some dst_ptr -> memcpy ~dst_ptr
-    | Streaming_for _, _ ->
-        if same_device then dst.stream.merge_buffer := Some { ptr = src_ptr; size_in_bytes }
-        else (
-          (* Fall back to copy for different devices *)
-          opt_alloc_merge_buffer ~size_in_bytes dst.stream;
-          let buffer = Option.value_exn ~here:[%here] !(dst.stream.merge_buffer) in
-          memcpy ~dst_ptr:buffer.ptr)
     | Copy, _ ->
         opt_alloc_merge_buffer ~size_in_bytes dst.stream;
         let buffer = Option.value_exn ~here:[%here] !(dst.stream.merge_buffer) in
@@ -401,7 +387,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     metal_source : string; (* Store source, compile during link if not already compiled *)
     compiled_code : Me.Library.t option array; (* Store compiled code per device *)
     func_name : string;
-    params : (string * param_source) list;
+    kparams : (string * kparam_source) list;
     bindings : Indexing.unit_bindings;
     traced_store : Low_level.traced_store;
   }
@@ -410,7 +396,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
   type code_batch = {
     metal_source : string; (* Store combined source *)
     compiled_code : Me.Library.t option array; (* Store compiled code per device *)
-    funcs : (string * (string * param_source) list) option array; (* func_name * params *)
+    funcs : (string * (string * kparam_source) list) option array; (* func_name * kparams *)
     bindings : Indexing.unit_bindings;
     traced_stores : Low_level.traced_store option array;
   }
@@ -685,7 +671,7 @@ end) : Ir.Backend_impl.Lowered_backend = struct
     end)) in
     let idx_params = Indexing.bound_symbols bindings in
     (* Add Metal address space qualifiers *)
-    let params, proc_doc = Syntax.compile_proc ~name idx_params lowered in
+    let kparams, proc_doc = Syntax.compile_proc ~name idx_params lowered in
     let metal_includes = {|#include <metal_stdlib>
 using namespace metal;|} in
     let source =
@@ -697,7 +683,7 @@ using namespace metal;|} in
       compiled_code = Array.create ~len:num_devs None;
       (* One slot per device *)
       func_name = name;
-      params;
+      kparams;
       bindings;
       traced_store = lowered.traced_store;
     }
@@ -711,8 +697,8 @@ using namespace metal;|} in
       Array.map2_exn names lowereds
         ~f:
           (Option.map2 ~f:(fun name lowered ->
-               let params, doc = Syntax.compile_proc ~name idx_params lowered in
-               ((name, params), doc)))
+               let kparams, doc = Syntax.compile_proc ~name idx_params lowered in
+               ((name, kparams), doc)))
     in
     let all_proc_docs = List.filter_map (Array.to_list funcs_and_docs) ~f:(Option.map ~f:snd) in
     let final_doc = PPrint.(separate hardline all_proc_docs) in
@@ -734,7 +720,7 @@ using namespace metal;|} in
     }
 
   let%debug4_sexp link_proc ~prior_context ~library ~func_name
-      ~(params : (string * param_source) list) ~lowered_bindings ~(ctx_arrays : buffer_ptr Tn.t_map)
+      ~(kparams : (string * kparam_source) list) ~lowered_bindings ~(ctx_arrays : buffer_ptr Tn.t_map)
       : Task.t =
     let stream = prior_context.stream in
     let device = stream.device.dev in
@@ -754,23 +740,23 @@ using namespace metal;|} in
         Me.ComputeCommandEncoder.set_compute_pipeline_state encoder pso;
 
         (* Set arguments *)
-        List.iteri params ~f:(fun index (_p_name, p_source) ->
+        List.iteri kparams ~f:(fun index (_p_name, p_source) ->
             match p_source with
-            | Param_ptr tn when Map.mem ctx_arrays tn ->
+            | Kparam_ptr tn when Map.mem ctx_arrays tn ->
                 let buffer = Map.find_exn ctx_arrays tn in
                 Me.ComputeCommandEncoder.set_buffer encoder ~index buffer
-            | Param_ptr tn when Tn.known_constant tn && Tn.is_hosted_force tn 48 ->
+            | Kparam_ptr tn when Tn.known_constant tn && Tn.is_hosted_force tn 48 ->
                 let buffer =
-                  Hashtbl.find_or_add stream.device.cross_stream_candidates tn ~default:(fun () ->
+                  Hashtbl.find_or_add stream.device.device_buffer_cache tn ~default:(fun () ->
                       get_buffer_for_ptr device ~size_in_bytes:(Lazy.force tn.size_in_bytes)
                       @@ Ndarray.get_voidptr_not_managed
                       @@ Option.value_exn ~here:[%here]
                       @@ Lazy.force tn.array)
                 in
                 Me.ComputeCommandEncoder.set_buffer encoder ~index buffer
-            | Param_ptr tn ->
+            | Kparam_ptr tn ->
                 failwith
-                  [%string "Param_ptr %{Tn.debug_name tn} not found in ctx_arrays for %{func_name}"]
+                  [%string "Kparam_ptr %{Tn.debug_name tn} not found in ctx_arrays for %{func_name}"]
             | Static_idx s ->
                 let value = !(Indexing.find_exn lowered_bindings s) in
                 let size = Ctypes.sizeof Ctypes.int in
@@ -817,7 +803,7 @@ using namespace metal;|} in
       List.map (Indexing.bound_symbols code.bindings) ~f:(fun s -> (s, ref 0))
     in
     let task =
-      link_proc ~prior_context ~library ~func_name:code.func_name ~params:code.params
+      link_proc ~prior_context ~library ~func_name:code.func_name ~kparams:code.kparams
         ~lowered_bindings ~ctx_arrays
     in
     (lowered_bindings, task)
@@ -831,9 +817,9 @@ using namespace metal;|} in
 
     let tasks =
       Array.mapi code_batch.funcs ~f:(fun i func_opt ->
-          Option.bind func_opt ~f:(fun (func_name, params) ->
+          Option.bind func_opt ~f:(fun (func_name, kparams) ->
               Option.map ctx_arrays_opts.(i) ~f:(fun ctx_arrays ->
-                  link_proc ~prior_context ~library ~func_name ~params ~lowered_bindings ~ctx_arrays)))
+                  link_proc ~prior_context ~library ~func_name ~kparams ~lowered_bindings ~ctx_arrays)))
     in
     (lowered_bindings, tasks)
 end

--- a/arrayjit/lib/metal_backend.mli
+++ b/arrayjit/lib/metal_backend.mli
@@ -1,5 +1,1 @@
-module Fresh : functor
-  (_ : sig
-     val config : Ir.Backend_intf.config
-   end)
-  -> Ir.Backend_impl.Lowered_backend
+module Fresh : Ir.Backend_impl.Lowered_backend

--- a/arrayjit/lib/metal_backend_impl.missing.ml
+++ b/arrayjit/lib/metal_backend_impl.missing.ml
@@ -1,9 +1,5 @@
-module Fresh (Config : sig
-  val config : Ir.Backend_intf.config
-end) =
+module Fresh =
 struct
-  let _ = ignore Config.config
-
   include Lowered_backend_missing.Missing (struct
     let name = "metal"
   end)

--- a/arrayjit/lib/metal_backend_impl.mli
+++ b/arrayjit/lib/metal_backend_impl.mli
@@ -1,5 +1,1 @@
-module Fresh : functor
-  (_ : sig
-     val config : Ir.Backend_intf.config
-   end)
-  -> Ir.Backend_impl.Lowered_backend
+module Fresh : Ir.Backend_impl.Lowered_backend

--- a/arrayjit/lib/schedulers.ml
+++ b/arrayjit/lib/schedulers.ml
@@ -16,7 +16,6 @@ module Multicore (Backend : For_add_scheduler) :
      and type optimize_ctx = Ir.Low_level.optimize_ctx = struct
   include Backend
   module Domain = Domain [@warning "-3"]
-  (* Currently, Backend.config is not used. *)
 
   type task_list = Ir.Task.t Utils.mutable_list [@@deriving sexp_of]
 
@@ -175,21 +174,23 @@ module Multicore (Backend : For_add_scheduler) :
       { state; domain = Domain.spawn worker }
     in
     (* We cannot use make_stream because runner needs stream_id. *)
-    Utils.register_new device.streams ~grow_by:8 (fun stream_id ->
-        let runner = create stream_id in
-        {
-          device;
-          runner;
-          merge_buffer = ref None;
-          stream_id;
-          allocated_buffer = None;
-          updating_for = Hashtbl.create (module Ir.Tnode);
-          updating_for_merge_buffer = None;
-          reader_streams = Hashtbl.create (module Ir.Tnode);
-        })
+    let stream_id = device.next_stream_id in
+    device.next_stream_id <- stream_id + 1;
+    let runner = create stream_id in
+    let stream =
+      {
+        device;
+        runner;
+        merge_buffer = ref None;
+        stream_id;
+        allocated_buffer = None;
+        merge_buffer_node = ref None;
+      }
+    in
+    device.current_stream <- Some stream;
+    stream
 
   let num_devices () = 1
-  let suggested_num_streams _device = Domain.recommended_domain_count () - 2
 
   let static_properties =
     Sexp.List
@@ -235,9 +236,6 @@ module Multicore (Backend : For_add_scheduler) :
   let get_debug_info (stream : stream) = sexp_of_runner stream.runner
 end
 
-(** For debugging, allow [Sync_scheduler(...).suggested_num_streams] calls to return >1 numbers. *)
-let sync_suggested_num_streams = ref 1
-
 (** A minimalisitc wrapper creating backends where all calls run synchronously on the main thread.
     There is only one device, but an arbitrary number of streams. *)
 module Sync (Backend : For_add_scheduler) = struct
@@ -274,7 +272,6 @@ module Sync (Backend : For_add_scheduler) = struct
     device
 
   let num_devices () = 1
-  let suggested_num_streams _ = !sync_suggested_num_streams
   let get_used_memory _ = Backend.get_used_memory ()
   let new_stream device = make_stream device ()
   let all_work _stream = ()

--- a/arrayjit/lib/tnode.ml
+++ b/arrayjit/lib/tnode.ml
@@ -9,35 +9,11 @@ let _get_local_debug_runtime = Utils.get_local_debug_runtime
 (* export OCANNL_LOG_LEVEL_TNODE=9 to enable debugging into the log_files/ directory. *)
 [%%global_debug_log_level_from_env_var "OCANNL_LOG_LEVEL_TNODE"]
 
-(** A possible algorithm for deciding sharing within a single device:
-    - If a tensor node is read-only for a context, and not otherwise recorded, it is stored as a
-      cross-stream sharing candidate.
-    - If a cross-stream sharing candidate is read-only for another context, whose parent does not
-      have the corresponding array (i.e. it is a different stream), it is recorded as cross-stream
-      shared, and the same array is reused.
-    - If a tensor node is writable by a context, and it is not cross-stream shared, it is marked as
-      non-cross-stream, the array is removed from cross-stream sharing candidates if present. If it
-      is cross-stream shared, it is recorded as owned by the corresponding stream. It is an error if
-      the node was already owned by a different stream.
-
-    If a tensor node is shared cross-stream, within-device copying is a NOOP as source and
-    destination pointers are in that case identical. *)
-type sharing =
-  | Unset  (** One of: [Per_stream], [Shared_cross_streams]. *)
-  | Per_stream  (** The tensor node has separate arrays for each stream. *)
-  | Shared_cross_streams
-      (** The tensor node has a single array per device that can appear in multiple contexts, except
-          for backends with [Option.is_some use_host_memory] and nodes with memory mode already
-          [Hosted (Changed_on_devices Shared_cross_streams)] before first linking on a device, where
-          it only has the on-host array. In that case the on-host array is registered in the
-          context, to avoid misleading behavior from `device_to_device`. *)
-[@@deriving sexp, compare, equal]
-
 type memory_type =
   | Unset_hosted
   | Constant  (** The tensor node does not change after initialization. *)
   | Nonconstant  (** One of: [Changed_on_devices], [Volatile]. *)
-  | Changed_on_devices of sharing
+  | Changed_on_devices
       (** The tensor node will only change on host via a [to_host] call. *)
   | Volatile
       (** The tensor node will only change on any device via a [from_host] call possibly followed by
@@ -52,7 +28,7 @@ type memory_mode =
       (** The full tensor node is cached for the duration of a computation but not persisted across
           calls to compiled functions. It is not available for merging across devices. *)
   | Device_only  (** One of: [Local], [On_device]. *)
-  | On_device of sharing
+  | On_device
       (** The tensor node is stored on the devices that compute with it and persisted across
           function calls. It is available for merging across devices (for devices that support
           merging / P2P), but not (directly) for visualization or storing to disk. *)
@@ -173,16 +149,12 @@ let debug_memory_mode = function
         | Local -> "Local"
         | Device_only -> "Dev"
         | Materialized -> "Material"
-        | On_device Unset -> "On-dev"
-        | On_device Shared_cross_streams -> "Dev-shared"
-        | On_device Per_stream -> "Dev-stream"
+        | On_device -> "On-dev"
         | Hosted Constant -> "Host-const"
         | Hosted Nonconstant -> "Host-non-const"
         | Hosted Unset_hosted -> "Host-unset"
         | Hosted Volatile -> "Hosted"
-        | Hosted (Changed_on_devices Unset) -> "Host&dev"
-        | Hosted (Changed_on_devices Per_stream) -> "Host&stream"
-        | Hosted (Changed_on_devices Shared_cross_streams) -> "Host&shared")
+        | Hosted Changed_on_devices -> "Host&dev")
       ^ "/" ^ Int.to_string prov
 
 let log_debug_info ~from_log_level tn =
@@ -204,7 +176,7 @@ let log_debug_info ~from_log_level tn =
         | (lazy (Some nd)) -> Nd.log_debug_info ~from_log_level nd
       else [%log "<not-in-yet>"]]]
 
-(** The one exception to "most local" is that the sharing property is kept at [Unset]. *)
+(** Defaults to the most local memory mode compatible with the current setting. *)
 let default_to_most_local tn provenance =
   let provenance =
     match tn.memory_mode with Some (_, prov) -> (1000 * prov) + provenance | None -> provenance
@@ -216,15 +188,15 @@ let default_to_most_local tn provenance =
     if
       stack_threshold_in_bytes > 0
       && num_elems tn > stack_threshold_in_bytes / (Ops.prec_in_bytes @@ Lazy.force tn.prec)
-    then On_device Unset
+    then On_device
     else Local
   in
   match tn.memory_mode with
   | None | Some (Effectively_constant, _) -> tn.memory_mode <- Some (Virtual, provenance)
   | Some (Never_virtual, _) -> tn.memory_mode <- Some (local_mode, provenance)
   | Some (Device_only, _) -> tn.memory_mode <- Some (local_mode, provenance)
-  | Some (Materialized, _) -> tn.memory_mode <- Some (On_device Unset, provenance)
-  | Some ((Virtual | Local | On_device _ | Hosted _), _) -> ()
+  | Some (Materialized, _) -> tn.memory_mode <- Some (On_device, provenance)
+  | Some ((Virtual | Local | On_device | Hosted _), _) -> ()
 
 let is_virtual_force tn provenance =
   match tn.memory_mode with
@@ -239,7 +211,7 @@ let is_virtual_force tn provenance =
 
 let rec is_hosted_force tn provenance =
   match tn.memory_mode with
-  | Some ((Virtual | Local | Device_only | On_device _), _) -> false
+  | Some ((Virtual | Local | Device_only | On_device), _) -> false
   | Some (Hosted _, _) -> true
   | None | Some ((Never_virtual | Materialized | Effectively_constant), _) ->
       default_to_most_local tn provenance;
@@ -249,7 +221,7 @@ let rec is_materialized_force tn provenance =
   match tn.memory_mode with
   | None -> assert false
   | Some ((Virtual | Local), _) -> false
-  | Some ((On_device _ | Hosted _ | Materialized), _) -> true
+  | Some ((On_device | Hosted _ | Materialized), _) -> true
   | Some ((Never_virtual | Device_only | Effectively_constant), _) ->
       default_to_most_local tn provenance;
       is_materialized_force tn provenance
@@ -257,7 +229,6 @@ let rec is_materialized_force tn provenance =
 let%debug3_sexp rec is_in_context_force ~(use_host_memory : 'a option) (tn : t) (provenance : int) :
     bool =
   match tn.memory_mode with
-  | Some (Hosted (Changed_on_devices Per_stream), _) -> true
   | Some ((Materialized | Hosted Nonconstant), _) when Option.is_none use_host_memory -> true
   | Some (Hosted (Constant | Volatile), _) when Option.is_some use_host_memory -> false
   | Some (Hosted _, _) -> true
@@ -265,7 +236,7 @@ let%debug3_sexp rec is_in_context_force ~(use_host_memory : 'a option) (tn : t) 
   | None | Some ((Materialized | Effectively_constant | Never_virtual | Device_only), _) ->
       default_to_most_local tn provenance;
       is_in_context_force ~use_host_memory tn provenance
-  | Some (On_device _, _) -> true
+  | Some (On_device, _) -> true
 
 let known_not_materialized tn =
   match tn.memory_mode with Some ((Virtual | Local), _) -> true | _ -> false
@@ -282,21 +253,6 @@ let known_non_virtual tn =
 
 let known_virtual tn = match tn.memory_mode with Some (Virtual, _) -> true | _ -> false
 
-let known_shared_cross_streams tn =
-  match tn.memory_mode with
-  | Some
-      ( ( On_device Shared_cross_streams
-        | Hosted (Constant | Volatile | Changed_on_devices Shared_cross_streams) ),
-        _ ) ->
-      true
-  | _ -> false
-
-let known_non_cross_stream tn =
-  match tn.memory_mode with
-  | Some ((On_device Per_stream | Hosted (Changed_on_devices Per_stream)), _) -> true
-  | _ -> false
-
-let potentially_cross_stream tn = not (known_not_materialized tn || known_non_cross_stream tn)
 
 let mode_is_unspecified tn =
   match tn.memory_mode with
@@ -322,13 +278,12 @@ let update_memory_mode tn mode provenance =
   | Some (Effectively_constant, old_prov), Hosted Unset_hosted ->
       tn.memory_mode <- Some (Hosted Constant, (old_prov * 1000) + provenance)
   | Some (Effectively_constant, _), Virtual -> tn.memory_mode <- Some (mode, provenance)
-  | ( Some (Hosted (Nonconstant | Unset_hosted | Changed_on_devices Unset), _),
-      Hosted (Changed_on_devices _ | Volatile) ) ->
+  | ( Some (Hosted (Nonconstant | Unset_hosted | Changed_on_devices), _),
+      Hosted (Changed_on_devices | Volatile) ) ->
       tn.memory_mode <- Some (mode, provenance)
   | Some (Hosted Unset_hosted, _), Hosted (Constant | Nonconstant) ->
       tn.memory_mode <- Some (mode, provenance)
-  | Some (Hosted (Changed_on_devices _ | Volatile), _), Hosted Nonconstant -> ()
-  | Some (Hosted (Changed_on_devices _), _), Hosted (Changed_on_devices Unset) -> ()
+  | Some (Hosted (Changed_on_devices | Volatile), _), Hosted Nonconstant -> ()
   | Some (Never_virtual, _), mode -> tn.memory_mode <- Some (mode, provenance)
   | Some (Virtual, prov2), Never_virtual ->
       raise
@@ -337,55 +292,18 @@ let update_memory_mode tn mode provenance =
              "Tnode.update_memory_mode: update %{prov2#Int} -> %{provenance#Int} for %{debug_name \
               tn} is already virtual"]
   | Some (_, _), Never_virtual -> ()
-  | Some (Device_only, _), (Local | On_device _) -> tn.memory_mode <- Some (mode, provenance)
-  | Some (On_device _, _), On_device Unset -> ()
-  | Some (On_device Unset, _), On_device _ -> tn.memory_mode <- Some (mode, provenance)
-  | Some (Materialized, _), (On_device _ | Hosted _) -> tn.memory_mode <- Some (mode, provenance)
-  | Some ((Local | On_device _), _), Device_only -> ()
-  | Some ((On_device _ | Hosted _), _), Materialized -> ()
+  | Some (Device_only, _), (Local | On_device) -> tn.memory_mode <- Some (mode, provenance)
+  | Some (On_device, _), On_device -> ()
+  | Some (Materialized, _), (On_device | Hosted _) -> tn.memory_mode <- Some (mode, provenance)
+  | Some ((Local | On_device), _), Device_only -> ()
+  | Some ((On_device | Hosted _), _), Materialized -> ()
   | Some (Device_only, _), Materialized | Some (Materialized, _), Device_only ->
-      tn.memory_mode <- Some (On_device Unset, provenance)
+      tn.memory_mode <- Some (On_device, provenance)
   | Some (_, prov2), _ ->
       invalid_arg
         [%string
           "Tnode.update_memory_mode: update %{prov2#Int} -> %{provenance#Int} inconsistent for \
            %{debug_name tn}"]
-
-(** [update_memory_sharing tn sharing provenance] preserves the memory mode of [tn] while updating
-    the cross-stream sharing property, except that [Hosted Nonconstant] is further specialized to
-    [Hosted (Changed_on_devices sharing)]. *)
-let update_memory_sharing tn sharing provenance =
-  match (tn.memory_mode, sharing) with
-  | None, _ -> tn.memory_mode <- Some (On_device sharing, provenance)
-  | Some (On_device Shared_cross_streams, _), Shared_cross_streams
-  | Some (On_device Per_stream, _), Per_stream ->
-      ()
-  | Some ((On_device Unset | Device_only | Materialized), old_prov), _ ->
-      tn.memory_mode <- Some (On_device sharing, provenance + (old_prov * 1000))
-  | Some (Hosted (Constant | Volatile), prov2), Per_stream ->
-      raise
-      @@ Utils.User_error
-           [%string
-             "Tnode.update_memory_sharing: update %{prov2#Int} -> %{provenance#Int} for \
-              %{debug_name tn} (hosted) -- currently hosted nodes not changed on devices must be \
-              shared cross-stream"]
-  | Some (Hosted (Changed_on_devices Shared_cross_streams), _), Shared_cross_streams
-  | Some (Hosted (Changed_on_devices Per_stream), _), Per_stream ->
-      ()
-  | Some (Hosted (Constant | Volatile), _), Shared_cross_streams -> ()
-  | Some (Hosted (Nonconstant | Unset_hosted | Changed_on_devices Unset), old_prov), _ ->
-      tn.memory_mode <- Some (Hosted (Changed_on_devices sharing), provenance + (old_prov * 1000))
-  | Some (_, prov2), Unset ->
-      invalid_arg
-        [%string
-          "Tnode.update_memory_sharing: update %{prov2#Int} -> %{provenance#Int} for %{debug_name \
-           tn} -- currently unsetting of sharing not allowed"]
-  | (Some (_, prov2) as mem_mode), _ ->
-      invalid_arg
-        [%string
-          "Tnode.update_memory_sharing: update %{prov2#Int} -> %{provenance#Int} inconsistent for \
-           %{debug_name tn}: old mode %{debug_memory_mode mem_mode}, new sharing \
-           %{Sexp.to_string_hum @@ sexp_of_sharing sharing}"]
 
 let update_prec ?only_if tn prec =
   let do_update =

--- a/docs/anatomy_of_a_backend.md
+++ b/docs/anatomy_of_a_backend.md
@@ -58,33 +58,10 @@ In the future, when we introduce program search, `compile` functions will return
 OCANNL classifies tensor nodes according to their memory properties:
 
  ```ocaml
- (** A possible algorithm for deciding sharing within a single device:
-    - If a tensor node is read-only for a context, and not otherwise recorded, it is stored as a
-      cross-stream sharing candidate.
-    - If a cross-stream sharing candidate is read-only for another context, whose parent does not
-      have the corresponding array (i.e. it is a different stream), it is recorded as cross-stream
-      shared, and the same array is reused.
-    - If a tensor node is writable by a context, and it is not cross-stream shared, it is marked as
-      non-cross-stream, the array is removed from cross-stream sharing candidates if present. If it
-      is cross-stream shared, it is recorded as owned by the corresponding stream. It is an error if
-      the node was already owned by a different stream.
-
-    If a tensor node is shared cross-stream, within-device copying is a NOOP as source and
-    destination pointers are in that case identical. *)
-type sharing =
-  | Unset  (** One of: [Per_stream], [Shared_cross_streams]. *)
-  | Per_stream  (** The tensor node has separate arrays for each stream. *)
-  | Shared_cross_streams
-      (** The tensor node has a single array per device that can appear in multiple contexts, except
-          for backends with [Option.is_some use_host_memory] and nodes with memory mode already
-          [Hosted (Changed_on_devices Shared_cross_streams)] before first linking on a device, where
-          it only has the on-host array. In that case the on-host array is registered in the
-          context, to avoid misleading behavior from `device_to_device`. *)
-
 type memory_type =
   | Constant  (** The tensor node does not change after initialization. *)
   | Nonconstant  (** One of: [Changed_on_devices], [Volatile]. *)
-  | Changed_on_devices of sharing
+  | Changed_on_devices
       (** The tensor node will only change on host via a [to_host] call. *)
   | Volatile
       (** The tensor node will only change on any device via a [from_host] call possibly followed by
@@ -98,7 +75,7 @@ type memory_mode =
       (** The full tensor node is cached for the duration of a computation but not persisted across
           calls to compiled functions. It is not available for merging across devices. *)
   | Device_only  (** One of: [Local], [On_device]. *)
-  | On_device of sharing
+  | On_device
       (** The tensor node is stored on the devices that compute with it and persisted across
           function calls. It is available for merging across devices (for devices that support
           merging / P2P), but not (directly) for visualization or storing to disk. *)
@@ -110,7 +87,7 @@ type memory_mode =
           optional [array] of {!t}). *)
  ```
 
- `Tnode.update_memory_mode` verifies consistency of the updates of these modes. Currently, these properties are either set explicitly (directly or indirectly) by the user, or determined by the `Low_level` analysis and optimization process and refined regarding sharing by the context array allocation process (generic across backends). Moreover, the `Tensor` module can influence whether the mode is constant (`Tensor.number`, `Tensor.ndarray`) or non-constant (`Tensor.param`).
+ `Tnode.update_memory_mode` verifies consistency of the updates of these modes. Currently, these properties are either set explicitly (directly or indirectly) by the user, or determined by the `Low_level` analysis and optimization process. Moreover, the `Tensor` module can influence whether the mode is constant (`Tensor.number`, `Tensor.ndarray`) or non-constant (`Tensor.param`).
 
 A backend can make more refined distinctions, for example a `Local` node in CUDA could optionally be shared across threads of a block.
 
@@ -151,52 +128,19 @@ When using the default stream, CUDA would predictably write to the standard outp
 
 ## Synchronization and data transfers
 
-OCANNL expects backends to implement FIFO queue scheduling, and an event mechanism for synchronizing between streams (and ideally devices), matching the CUDA specification. On top of events, OCANNL implements per-tensor-node synchronization. 1/3rd of the `device` fields have to do with synchronization:
+OCANNL expects backends to implement FIFO queue scheduling, and an event mechanism for asynchronous operation tracking. Each device has a single execution context (stream). Events track whether a stream has finished computing past a particular point, and are used for async GPU correctness (e.g. waiting for a transfer to complete before reading the result).
 
-```ocaml
-  shared_writer_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams that most recently have been scheduled to update (write to) a
-          cross-stream-shared node, and the associated update completion event. The completed events
-          are removed opportunistically. *)
-  host_reading_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams that most recently have been reading from a node's on-host array. The
-          completed events are removed opportunistically. *)
-  host_writing_streams :
-    (('buffer_ptr, 'dev, 'runner, 'event) stream * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams that most recently have been writing to a node's on-host array. The completed
-          events are removed opportunistically. *)
-```
-
-and some stream fields also:
-
-```ocaml
-  updating_for : 'event Hashtbl.M(Tnode).t;
-      (* The completion event for updating (writing to) a node via this stream, if any. *)
-  mutable updating_for_merge_buffer : (Tnode.t * 'event option) option;
-      (** The tensor node that was most recently scheduled to be in the [stream]'s merge buffer. The
-          event finishes after the [task] from a [Streaming_for task]. See also
-          {!field-updating_for}. *)
-  reader_streams : (('buffer_ptr, 'dev, 'runner, 'event) stream * 'event) list Hashtbl.M(Tnode).t;
-      (** The streams, other than this stream, that most recently have been reading from a node in
-          this stream's context, and the associated use completion events. The completed events are
-          removed opportunistically. *)
-```
-
-While we never share merge buffers across streams, there is always an event associated with an occupied merge buffer. Its primary use is for tracking the merge buffer's stream as a reader on the source stream.
-
-Besides routines, calling `from_host`, `to_host`, `device_to_device` from a backend puts the corresponding tasks on the device's queue. Both invoking a routine and calling these copying functions will perform the necessary event creations and synchronizations to ensure that when scheduling writing into an array precedes scheduling reading from it, the actual writing also precedes the actual reading.
+Besides routines, calling `from_host`, `to_host`, `device_to_device` from a backend puts the corresponding tasks on the device's queue. Invoking a routine and calling these copying functions will perform the necessary event tracking to ensure correct ordering of reads and writes.
 
 ### Data transfers
 
-OCANNL supports asynchronous data transfers -- `from_host`, `to_host`, `device_to_device` -- by embedding them in the scheduling mechanism. The transfers themselves synchronize streams in a non-blocking way -- when it's time for the destination stream to copy a node, it waits for the source stream to finish computing the node.
+OCANNL supports asynchronous data transfers -- `from_host`, `to_host`, `device_to_device` -- by embedding them in the scheduling mechanism.
 
-OCANNL provides explicit _merge buffers_ for performing those tensor node updates, where different versions of a tensor node from two streams feature in the same computation. The `%cd` syntax for using merge buffers is via the `.merge` pseudo-field. For example, the code for merging gradients might be: `[%cd p.grad =+ p.grad.merge]`. In the current design, there's at most one merge buffer per stream, and the memory is reused for merging different nodes. We keep track of the specific tensor node that was scheduled to occupy this buffer in the stream, and the merge node expected by the linked code, so that we can detect mismatches at scheduling time.
+OCANNL provides explicit _merge buffers_ for performing tensor node updates where different versions of a tensor node from two devices feature in the same computation. The `%cd` syntax for using merge buffers is via the `.merge` pseudo-field. For example, the code for merging gradients might be: `[%cd p.grad =+ p.grad.merge]`. In the current design, there's at most one merge buffer per device stream, and the memory is reused for merging different nodes. We keep track of the specific tensor node that was scheduled to occupy this buffer, and the merge node expected by the linked code, so that we can detect mismatches at scheduling time.
 
-The interface exposes two modes of utilizing merge buffers. The `Streaming_for` mode relies in some way on the array from the source context. Currently, this simply means using the source array (buffer) pointer, and the CUDA backend falls back to using `~into_merge_buffer:Copy` when the source and destination contexts live on different devices. The `Copy` mode uses physical arrays to back merge buffers. The merge buffer array (one per stream) is resized (grown) if needed to fit a node's array. To block the source stream from overwriting the array, `Streaming_for` is parameterized by the task (actually, routine) intended to make use of the merge buffer.
+The `Copy` mode uses physical arrays to back merge buffers. The merge buffer array is resized (grown) if needed to fit a node's array.
 
-Currently, OCANNL does not support merge buffers for `from_host` transfers. But it might in the future. Currently, combining `to_host` and `from_host` is the only way to make different backends cooperate, and that requires `from_host ~into_merge_buffer` to adapt single-backend design patterns.
+Currently, OCANNL does not support merge buffers for `from_host` transfers. Currently, combining `to_host` and `from_host` is the only way to make different backends cooperate.
 
 #### Automated transfers to / from host
 

--- a/test/operations/rope_test.expected
+++ b/test/operations/rope_test.expected
@@ -1,4 +1,5 @@
-
+Retrieving commandline, environment, or config file variable ocannl_log_level
+Found 0, in the config file
 === Test 1: Deinterleave roundtrip ===
 Original: 1 2 3 4 5 6 
 Roundtrip: 1 2 3 4 5 6 


### PR DESCRIPTION
## Summary

- Remove `config` type, `suggested_num_streams`, and `Streaming_for` variant
- Remove `sharing` type (`Per_stream`/`Shared_cross_streams`); simplify `On_device` and `Changed_on_devices` to no longer take a parameter
- Remove cross-stream synchronization from `backends.ml` (`wait_for_all`, multi-stream event tracking, cross-stream allocation logic)
- Remove stream-tracking fields from `device_ref` and `stream_ref`; rename `cross_stream_candidates` to `device_buffer_cache`
- Remove `round_robin`/`round_robin_dry_run` from `train.ml`
- Simplify CUDA, Metal, CC backend functors (remove `Config` parameter)
- Update docs, README milestone checkbox, ROADMAP, CHANGES.md

22 files changed, 152 insertions, 581 deletions.

## Test plan

- [x] `dune build @check` passes
- [x] Training tests pass: `moons_demo`, `bigram`, `fsm_transformer`
- [x] `moons_demo_variant.expected` updated via `dune promote` (cosmetic debug string changes)
- [x] Pre-existing `test_max_pool2d` failure confirmed unrelated (shape inference bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)