### PR TITLE
Bump cudajit pin to the CUDA-13 compatibility fixes

### DIFF
--- a/arrayjit.opam
+++ b/arrayjit.opam
@@ -67,6 +67,6 @@ x-maintenance-intent: ["(latest)"]
 pin-depends: [
   ["ppx_minidebug.dev" "git+https://github.com/lukstafi/ppx_minidebug.git#86a19de906add05caa0aa1626add1572da2f070d"]
   ["notty-community.dev" "git+https://github.com/lukstafi/notty-community.git#708e36ba78ecb4ec1bf12de2b087e549d6e42893"]
-  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#fb2b55284d90c682d771bd0fdd578ef77f229541"]
+  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#de2a51914f24a55e942bbb3f8a5d8a934f96dfaf"]
   ["hipjit.dev" "git+https://github.com/lukstafi/ocaml-hipjit.git#6ddb7bab60a0aabc2f63a4061e714332027fd94a"]
 ]

--- a/arrayjit.opam
+++ b/arrayjit.opam
@@ -67,6 +67,6 @@ x-maintenance-intent: ["(latest)"]
 pin-depends: [
   ["ppx_minidebug.dev" "git+https://github.com/lukstafi/ppx_minidebug.git#86a19de906add05caa0aa1626add1572da2f070d"]
   ["notty-community.dev" "git+https://github.com/lukstafi/notty-community.git#708e36ba78ecb4ec1bf12de2b087e549d6e42893"]
-  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#de2a51914f24a55e942bbb3f8a5d8a934f96dfaf"]
+  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#e62f9704a3a673c7f813252b77699ece0ef0a1ee"]
   ["hipjit.dev" "git+https://github.com/lukstafi/ocaml-hipjit.git#6ddb7bab60a0aabc2f63a4061e714332027fd94a"]
 ]

--- a/arrayjit.opam.template
+++ b/arrayjit.opam.template
@@ -1,6 +1,6 @@
 pin-depends: [
   ["ppx_minidebug.dev" "git+https://github.com/lukstafi/ppx_minidebug.git#86a19de906add05caa0aa1626add1572da2f070d"]
   ["notty-community.dev" "git+https://github.com/lukstafi/notty-community.git#708e36ba78ecb4ec1bf12de2b087e549d6e42893"]
-  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#fb2b55284d90c682d771bd0fdd578ef77f229541"]
+  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#de2a51914f24a55e942bbb3f8a5d8a934f96dfaf"]
   ["hipjit.dev" "git+https://github.com/lukstafi/ocaml-hipjit.git#6ddb7bab60a0aabc2f63a4061e714332027fd94a"]
 ]

--- a/arrayjit.opam.template
+++ b/arrayjit.opam.template
@@ -1,6 +1,6 @@
 pin-depends: [
   ["ppx_minidebug.dev" "git+https://github.com/lukstafi/ppx_minidebug.git#86a19de906add05caa0aa1626add1572da2f070d"]
   ["notty-community.dev" "git+https://github.com/lukstafi/notty-community.git#708e36ba78ecb4ec1bf12de2b087e549d6e42893"]
-  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#de2a51914f24a55e942bbb3f8a5d8a934f96dfaf"]
+  ["cudajit.dev" "git+https://github.com/lukstafi/ocaml-cudajit.git#e62f9704a3a673c7f813252b77699ece0ef0a1ee"]
   ["hipjit.dev" "git+https://github.com/lukstafi/ocaml-hipjit.git#6ddb7bab60a0aabc2f63a4061e714332027fd94a"]
 ]


### PR DESCRIPTION
Part of #482: the CUDA-13 cudajit fixes are now upstreamed in [lukstafi/ocaml-cudajit#14](https://github.com/lukstafi/ocaml-cudajit/pull/14), and this bumps the `cudajit.dev` pin from `fb2b5528` to `de2a5191` (the head of that PR's branch) in `arrayjit.opam.template` and the generated `arrayjit.opam`.

The pinned commit brings:
- `cuCtxCreate` arity shim for CUDA 13's `cuCtxCreate_v4`
- `nvrtcCompileProgram` constness shim for gcc >= 14
- MinGW/flexlink handling of CUDA 13's `cuda.lib` `/DEFAULTLIB` directives
- runtime PTX `.version` downgrade fallback for `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` (toolkit newer than driver)

Verified on Windows 11 / MinGW OCaml 5.5.0 / CUDA 13.3 with a driver that rejects nvrtc 13.3's PTX: cudajit's full GPU test suite passes with these fixes (module loads fail with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` without them).

Note: if lukstafi/ocaml-cudajit#14 is squash- or rebase-merged, the pin should be advanced to the resulting commit on `main` (a plain merge keeps `de2a5191` reachable). Remaining #482 items (hardware validation of `schedule_mma_matmul` f16/fp8, release coordination) are not covered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)