### PR TITLE
Windows workflow improvements: opam env for POSIX shells, LF goldens, portable test printers, linker-noise filter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Golden test outputs are byte-compared by dune and must stay LF everywhere:
+# `dune promote` on Windows writes CRLF (text-mode stdout), and CRLF checkouts
+# break `.missing.ml` stubs that echo goldens byte-for-byte. eol=lf makes git
+# store and check out these files with LF regardless of core.autocrlf, and
+# keeps promote-introduced CRs out of `git diff`/`git add`.
+*.expected text eol=lf
+test/ppx/*_expected.ml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,7 @@
 # keeps promote-introduced CRs out of `git diff`/`git add`.
 *.expected text eol=lf
 test/ppx/*_expected.ml text eol=lf
+
+# Shell scripts must check out with LF: bash chokes on CR under
+# core.autocrlf=true checkouts (the default on Windows installs).
+*.sh text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,9 @@ opam install cudajit  # for CUDA backend
 opam install hipjit   # for AMD HIP backend
 ```
 
-**Worktrees**: place new ones outside the repo — they need none of what follows. A worktree nested inside the repo (`.claude/worktrees/`, the Claude Code default) makes dune silently resolve the PARENT checkout as the project root: from those, pass `--root .` to dune commands run from the worktree root, and promote with `dune promotion apply` (`dune promote` rejects `--root`).
+**Worktrees**: place new ones outside the repo — they need none of what follows. A worktree nested inside the repo (`.claude/worktrees/`, the Claude Code default) makes dune silently resolve the PARENT checkout as the project root: from those, pass `--root .` to dune commands run from the worktree root, and promote with `dune promotion apply` (`dune promote` rejects `--root`) — or just use `tools/promote.sh`, which does both.
+
+**Windows shells**: `opam env --shell=sh` emits cygwin-style paths that break under Git Bash (MSYS), so a Git Bash session without a primed environment gets a half-working toolchain (dune found but linking fails with `cygpath: error converting ... -lpthread`). Source `tools/opam-env.sh` first — it rewrites the paths for MSYS and works from any POSIX shell. On Windows, link steps also flood stderr with benign binutils warnings (`Warning: corrupt .drectve at end of def file`, from MSVC-produced import libraries like ROCm's/CUDA's); `tools/dune-quiet.sh <dune args>` runs dune with exactly those lines filtered, preserving the exit status.
 
 **Formatting**: the repo is not fully ocamlformat-clean, and CI does not enforce formatting — do NOT run `dune fmt` as part of feature work (it reformats the entire repo and pollutes the diff; recover from an accidental sweep with `git restore .`). Match the surrounding style by hand; to check just your own lines, diff against `_build/default/<dir>/.formatted/<file>`. Formatting-state updates land as standalone formatting commits, paired with updating `.ocamlformat-ignore` — ppx-expectation files (`test/ppx/*_expected.ml`, compared against pretty-printed ppx output) must stay unformatted, so add new ones to that list.
 
@@ -119,7 +121,7 @@ opam install hipjit   # for AMD HIP backend
 **Test Types**:
 - **Inline tests**: Files included in library `modules` field with `inline_tests` stanza (e.g., `test_threefry4x32.ml` in `operations_tutorials` library)
 - **Standalone tests**: Files with dedicated `test` stanza and corresponding `.expected` files (e.g., `threefry4x32_demo`)
-- Use `dune promote` to accept test output changes
+- Use `dune promote` to accept test output changes (on Windows or in a nested worktree, prefer `tools/promote.sh` — it applies the promotion with the right root and strips CRLF from promoted goldens)
 - A few `%expect_test` blocks capture exception backtraces that hard-code `file:line` (e.g. `test/operations/primitive_ops.ml` embeds `context.ml` line numbers). Any edit that shifts lines in such a file forces a line-number-only re-promote — benign noise, not a behavior change; promote it in the same shell as the failing run (the `.ml.corrected` can vanish between runs)
 - For optimizer passes that change *what value a cell holds* (virtualization guards, index solving, accumulation/init elision), a structural test on the emitted op tree is necessary but NOT sufficient — also assert on executed output vs. a materialized/reference run (`Context.compile`/`run`/`get_values`); a pass has shipped green structural checks while computing all zeros
 - Backend codegen snapshots (e.g. `.cu.expected` files, `test_cuda_pool_offset.expected`) go stale when codegen changes land without that backend's hardware available to re-record them — expect to re-promote such snapshots when the hardware next runs the suite
@@ -133,9 +135,10 @@ opam install hipjit   # for AMD HIP backend
   * Tests that enable `output_debug_files_in_build_directory` in one directory all execute from the same `_build` directory and share `build_files/`, and dune runs them concurrently — always give kernels/tensors a test-unique name prefix (like the existing `af_`, `ops_`, `smem_` conventions), otherwise same-named generated sources get torn by concurrent writers
 
 **Windows portability for `.expected` tests**:
-- `dune promote` on Windows writes CRLF line endings into `.expected` files (the test exe's stdout is text-mode); after promoting, normalize with `sed -i 's/\r$//' <file>`. PowerShell `Set-Content`/`Out-File` also write CRLF — edit `.expected` files with bash tools instead
+- `dune promote` on Windows writes CRLF line endings into `.expected` files (the test exe's stdout is text-mode). `.gitattributes` pins `*.expected` (and `test/ppx/*_expected.ml`) to LF, so git normalizes them on commit and promote-introduced CRs stay out of diffs; promoting via `tools/promote.sh` strips them from the working tree too. PowerShell `Set-Content`/`Out-File` also write CRLF — edit `.expected` files with bash tools instead
 - The Windows C runtime prints 3-digit float exponents (`e+018` where Linux prints `e+18`) — format floats destined for `.expected` files with `Ir.Ndarray.concise_float ~prec` (normalizes exponents portably) instead of `%g`/`%e`
 - The Windows C runtime rounds representable decimal ties away from zero while glibc rounds to even (`%.1f` of `2.25` prints `2.3` on Windows, `2.2` on Linux) — avoid tie values in test data, or print with OCaml's `%h` hex-float format, which sidesteps decimal rounding entirely
+- The `test_utils` library (`test/support/test_utils.ml`) packages these rules as portable-by-construction printers (`print_float`/`print_floats`/`hex_float`, plus `set_binary_stdout` for stubs that echo a golden file byte-for-byte) — add `test_utils` to a new test's `(libraries ...)` instead of re-deriving them
 
 **Module Paths and Common APIs**:
 

--- a/test/support/dune
+++ b/test/support/dune
@@ -1,0 +1,4 @@
+(library
+ (name test_utils)
+ (package neural_nets_lib)
+ (libraries base stdio arrayjit.ir))

--- a/test/support/test_utils.ml
+++ b/test/support/test_utils.ml
@@ -1,0 +1,33 @@
+(** Portable output helpers for OCANNL tests.
+
+    The Windows and glibc C runtimes format floats differently: Windows prints 3-digit exponents
+    ([e+018] vs. Linux's [e+18]) and rounds representable decimal ties away from zero where glibc
+    rounds to even ([%.1f] of [2.25] prints [2.3] on Windows, [2.2] on Linux). Tests that print
+    floats with raw [%g]/[%e]/[%f] into [.expected] files therefore fail across platforms. Use
+    these printers instead — they are portable by construction. *)
+
+open Base
+open Stdio
+
+(** [concise_float ~prec v] formats [v] with [prec] decimals, normalizing exponent digits portably.
+    Re-export of [Ir.Ndarray.concise_float]. *)
+let concise_float = Ir.Ndarray.concise_float
+
+(** [hex_float v] formats [v] with OCaml's [%h] hex-float notation: bit-exact on every platform,
+    sidestepping decimal-tie rounding divergence entirely. *)
+let hex_float v = Printf.sprintf "%h" v
+
+(** Prints [v] via [concise_float]. *)
+let print_float ?(prec = 6) v = printf "%s" (concise_float ~prec v)
+
+(** Prints [v] via [concise_float], followed by a newline. *)
+let print_float_ln ?(prec = 6) v = printf "%s\n" (concise_float ~prec v)
+
+(** Prints [vs] separated by [sep] (default a single space) via [concise_float]. *)
+let print_floats ?(prec = 6) ?(sep = " ") vs =
+  printf "%s" (String.concat ~sep (List.map vs ~f:(concise_float ~prec)))
+
+(** Puts stdout in binary mode. Required when echoing a golden [.expected] file byte-for-byte
+    (e.g. in [.missing.ml] backend stubs): text-mode stdout on Windows rewrites ["\n"] to
+    ["\r\n"], corrupting the comparison. *)
+let set_binary_stdout () = Out_channel.set_binary_mode stdout true

--- a/tools/dune-quiet.sh
+++ b/tools/dune-quiet.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Run dune with benign mingw linker noise filtered out of stderr.
+#
+# On Windows, every link step floods stderr with binutils warnings triggered by
+# MSVC-produced import libraries (e.g. the ROCm/CUDA ones):
+#
+#   Warning: corrupt .drectve at end of def file
+#   Warning: .drectve `...' unrecognized
+#
+# They are harmless but bury real errors. This wrapper drops exactly those
+# lines, passes everything else through unchanged (stdout untouched), and
+# preserves dune's exit status.
+#
+# Usage: tools/dune-quiet.sh <any dune arguments>
+#   e.g. tools/dune-quiet.sh build --root . @check
+
+command -v dune >/dev/null 2>&1 || . "$(dirname "$0")/opam-env.sh"
+
+status=0
+{
+  dune "$@" 2>&1 1>&3 3>&- \
+    | grep -vE 'Warning: (corrupt \.drectve at end of def file|\.drectve .* unrecognized)' >&2
+  status=${PIPESTATUS[0]}
+} 3>&1
+exit "$status"

--- a/tools/opam-env.sh
+++ b/tools/opam-env.sh
@@ -1,0 +1,37 @@
+# Bring the opam switch environment into any POSIX shell:
+#
+#   . tools/opam-env.sh          # or: source tools/opam-env.sh
+#
+# Motivation: on Windows, `opam env --shell=sh` emits cygwin-style paths
+# (`/cygdrive/c/...`, plus `/usr/...` entries relative to opam's bundled cygwin
+# root). Git Bash (MSYS) mounts drives at `/c` and has its own `/usr`, so
+# eval'ing that output verbatim leaves the toolchain half-broken — dune finds
+# the wrong `cygpath`/mingw tools and linking fails with errors like
+# `cygpath: error converting ... -lpthread`. This script rewrites those
+# prefixes for MSYS before eval'ing, so plain Git Bash sessions (including
+# non-interactive ones that never saw a profile-primed environment) can build.
+#
+# Costs one `opam env` call; safe to source multiple times.
+
+if ! command -v opam >/dev/null 2>&1; then
+  echo "tools/opam-env.sh: opam not found on PATH" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+_opam_env="$(opam env --shell=sh)" || {
+  echo "tools/opam-env.sh: 'opam env' failed" >&2
+  return 1 2>/dev/null || exit 1
+}
+
+case "$(uname -o 2>/dev/null)" in
+  Msys)
+    # Drive mounts: /cygdrive/c/... -> /c/...
+    # Switch-internal cygwin paths: /usr/... -> <opam root>/.cygwin/root/usr/...
+    _opam_cygroot="$(cygpath -u "$(opam var root)")/.cygwin/root"
+    _opam_env="$(printf '%s\n' "$_opam_env" \
+      | sed -e "s|:/usr/|:$_opam_cygroot/usr/|g" -e "s|/cygdrive/|/|g")"
+    ;;
+esac
+
+eval "$_opam_env"
+unset _opam_env _opam_cygroot

--- a/tools/promote.sh
+++ b/tools/promote.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Promote dune test outputs and normalize line endings in the promoted goldens.
+#
+# `dune promote` on Windows copies CRLF test output into `.expected` files
+# (test exe stdout is text-mode); goldens are LF in the repo (.gitattributes).
+# This wrapper promotes and then strips trailing CRs from the promoted files,
+# replacing the manual `sed -i 's/\r$//'` ritual. It also works from worktrees
+# nested inside the repo, where plain `dune promote` resolves the PARENT
+# checkout: `dune promotion apply` accepts the `--root .` override.
+#
+# Usage: tools/promote.sh [FILES...]
+#   Run from anywhere; extra arguments are passed through to dune (e.g. paths
+#   of specific files to promote).
+
+set -eu
+cd "$(dirname "$0")/.."
+
+command -v dune >/dev/null 2>&1 || . tools/opam-env.sh
+
+dune promotion apply --root . "$@"
+
+# Strip trailing CRs from any promoted golden that now differs from the index.
+git diff --name-only -z -- '*.expected' 'test/ppx/*_expected.ml' \
+  | while IFS= read -r -d '' f; do
+      [ -f "$f" ] && sed -i 's/\r$//' "$f"
+    done


### PR DESCRIPTION
Implements the Windows workflow improvements suggested in review of recent dev sessions:

1. **`tools/opam-env.sh`** — sourceable from any POSIX shell. On Windows, `opam env --shell=sh` emits cygwin-style paths (`/cygdrive/c/...`, and `/usr/...` entries relative to opam's bundled cygwin root) that Git Bash (MSYS) cannot resolve, leaving dune findable but linking broken (`cygpath: error converting ... -lpthread`). The script rewrites those prefixes before eval'ing. Verified in Git Bash: after sourcing, `dune` resolves to the switch binary and every opam-contributed PATH entry exists.

2. **CRLF at the tooling level** — `.gitattributes` pins `*.expected`, `test/ppx/*_expected.ml`, and `*.sh` to `text eol=lf` (all committed goldens are already LF, so no renormalization churn), and `tools/promote.sh` replaces the "promote then `sed -i 's/\r$//'`" ritual: it runs `dune promotion apply --root .` (also correct from worktrees nested inside the repo) and strips trailing CRs from promoted goldens. Verified end-to-end with a simulated CRLF promote.

3. **`test_utils` library** (`test/support/`) — portable-by-construction printers so new tests stop rediscovering the `e+018` and tie-rounding pitfalls: `concise_float` re-export, `print_float`/`print_float_ln`/`print_floats`, `%h` `hex_float`, and `set_binary_stdout` for stubs that echo goldens byte-for-byte.

4. **`tools/dune-quiet.sh`** — runs dune with the benign mingw/binutils warnings from MSVC-produced import libraries (`Warning: corrupt .drectve at end of def file`, `Warning: .drectve ... unrecognized`) filtered from stderr, preserving stdout and the exit status. Verified with a mock: exit code propagates, real errors stay visible.

5. **Windows CI** — already covered: `ci.yml` runs `windows-latest` with full `dune build` + `dune runtest` and is green on master, so no change needed.

CLAUDE.md updated to point at the new tooling.

Note: the dev machine's toolchain was blocked by a Windows Application Control policy during this work, so the new `test/support` library is compile-checked by this PR's CI rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)